### PR TITLE
Add and pass TreeConstructorFn argument to RepairExtendedDataSquare

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -43,7 +43,13 @@ func (e *UnrepairableDataSquareError) Error() string {
 
 // RepairExtendedDataSquare repairs an incomplete extended data square, against its expected row and column merkle roots.
 // Missing data chunks should be represented as nil.
-func RepairExtendedDataSquare(rowRoots [][]byte, columnRoots [][]byte, data [][]byte, codec CodecType) (*ExtendedDataSquare, error) {
+func RepairExtendedDataSquare(
+	rowRoots [][]byte,
+	columnRoots [][]byte,
+	data [][]byte,
+	codec CodecType,
+	treeCreatorFn TreeConstructorFn,
+) (*ExtendedDataSquare, error) {
 	matrixData := make([]float64, len(data))
 	var chunkSize int
 	for i := range data {
@@ -69,7 +75,7 @@ func RepairExtendedDataSquare(rowRoots [][]byte, columnRoots [][]byte, data [][]
 		}
 	}
 
-	eds, err := ImportExtendedDataSquare(data, codec, NewDefaultTree)
+	eds, err := ImportExtendedDataSquare(data, codec, treeCreatorFn)
 	if err != nil {
 		return nil, err
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -31,7 +31,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13] = nil, nil
 		var result *ExtendedDataSquare
-		result, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec)
+		result, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec, NewDefaultTree)
 		if err != nil {
 			t.Errorf("unexpected err while repairing data square: %v, codec: :%v", err, codec)
 		} else {
@@ -46,7 +46,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13], flattened[14] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec)
+		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair an unrepairable square")
 		}
@@ -57,7 +57,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corruptChunk := bytes.Repeat([]byte{66}, bufferSize)
 		corrupted.setCell(0, 0, corruptChunk)
-		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), corrupted.flattened(), codec)
+		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
 		}
@@ -68,7 +68,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%v", err, codec)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec)
+		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if err, ok = err.(*ByzantineRowError); !ok {
 			t.Errorf("did not return a ByzantineRowError for a bad row; got: %v", err)
 		}
@@ -78,7 +78,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%v", err, codec)
 		}
 		corrupted.setCell(0, 3, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec)
+		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if err, ok = err.(*ByzantineRowError); !ok {
 			t.Errorf("did not return a ByzantineRowError for a bad row; got %v", err)
 		}
@@ -90,7 +90,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec)
+		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
 		if err, ok = err.(*ByzantineColumnError); !ok {
 			t.Errorf("did not return a ByzantineColumnError for a bad column; got %v", err)
 		}
@@ -102,7 +102,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(3, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec)
+		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
 		if err, ok = err.(*ByzantineColumnError); !ok {
 			t.Errorf("did not return a ByzantineColumnError for a bad column; got %v", err)
 		}


### PR DESCRIPTION
Simple enough, we just have to pass a `rsmt2d.TreeConstructorFn` to `RepairExtendedDataSquare` so that we can eventually pass a nmt wrapper that is aware of hard code parity namespaces.

closes #15 