### PR TITLE
add cell index to the Push method of Tree

### DIFF
--- a/datasquare.go
+++ b/datasquare.go
@@ -167,7 +167,7 @@ func (ds *dataSquare) RowRoot(x uint) []byte {
 
 	tree := ds.createTreeFn()
 	for i, d := range ds.Row(x) {
-		tree.Push(d, CellIndex{CellIndex: uint(i), AxisIndex: x})
+		tree.Push(d, SquareIndex{Cell: uint(i), Axis: x})
 	}
 
 	return tree.Root()
@@ -191,7 +191,7 @@ func (ds *dataSquare) ColRoot(y uint) []byte {
 
 	tree := ds.createTreeFn()
 	for i, d := range ds.Column(y) {
-		tree.Push(d, CellIndex{CellIndex: uint(i), AxisIndex: y})
+		tree.Push(d, SquareIndex{Axis: y, Cell: uint(i)})
 	}
 
 	return tree.Root()
@@ -202,7 +202,7 @@ func (ds *dataSquare) computeRowProof(x uint, y uint) ([]byte, [][]byte, uint, u
 	data := ds.Row(x)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], CellIndex{CellIndex: uint(i), AxisIndex: y})
+		tree.Push(data[i], SquareIndex{Axis: y, Cell: uint(i)})
 	}
 
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(y))
@@ -214,7 +214,7 @@ func (ds *dataSquare) computeColumnProof(x uint, y uint) ([]byte, [][]byte, uint
 	data := ds.Column(y)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], CellIndex{CellIndex: uint(i), AxisIndex: y})
+		tree.Push(data[i], SquareIndex{Axis: y, Cell: uint(i)})
 	}
 	// TODO(ismail): check for overflow when casting from uint -> int
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(x))

--- a/datasquare.go
+++ b/datasquare.go
@@ -166,8 +166,8 @@ func (ds *dataSquare) RowRoot(x uint) []byte {
 	}
 
 	tree := ds.createTreeFn()
-	for _, d := range ds.Row(x) {
-		tree.Push(d)
+	for i, d := range ds.Row(x) {
+		tree.Push(d, CellIndex{Axis: Row, CellIndex: uint(i), AxisIndex: x})
 	}
 
 	return tree.Root()
@@ -190,8 +190,8 @@ func (ds *dataSquare) ColRoot(y uint) []byte {
 	}
 
 	tree := ds.createTreeFn()
-	for _, d := range ds.Column(y) {
-		tree.Push(d)
+	for i, d := range ds.Column(y) {
+		tree.Push(d, CellIndex{Axis: Col, CellIndex: uint(i), AxisIndex: y})
 	}
 
 	return tree.Root()
@@ -202,7 +202,7 @@ func (ds *dataSquare) computeRowProof(x uint, y uint) ([]byte, [][]byte, uint, u
 	data := ds.Row(x)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i])
+		tree.Push(data[i], CellIndex{Axis: Row, CellIndex: uint(i), AxisIndex: y})
 	}
 
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(y))
@@ -214,7 +214,7 @@ func (ds *dataSquare) computeColumnProof(x uint, y uint) ([]byte, [][]byte, uint
 	data := ds.Column(y)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i])
+		tree.Push(data[i], CellIndex{Axis: Col, CellIndex: uint(i), AxisIndex: y})
 	}
 	// TODO(ismail): check for overflow when casting from uint -> int
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(x))

--- a/datasquare.go
+++ b/datasquare.go
@@ -167,7 +167,7 @@ func (ds *dataSquare) RowRoot(x uint) []byte {
 
 	tree := ds.createTreeFn()
 	for i, d := range ds.Row(x) {
-		tree.Push(d, CellIndex{Axis: Row, CellIndex: uint(i), AxisIndex: x})
+		tree.Push(d, CellIndex{CellIndex: uint(i), AxisIndex: x})
 	}
 
 	return tree.Root()
@@ -191,7 +191,7 @@ func (ds *dataSquare) ColRoot(y uint) []byte {
 
 	tree := ds.createTreeFn()
 	for i, d := range ds.Column(y) {
-		tree.Push(d, CellIndex{Axis: Col, CellIndex: uint(i), AxisIndex: y})
+		tree.Push(d, CellIndex{CellIndex: uint(i), AxisIndex: y})
 	}
 
 	return tree.Root()
@@ -202,7 +202,7 @@ func (ds *dataSquare) computeRowProof(x uint, y uint) ([]byte, [][]byte, uint, u
 	data := ds.Row(x)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], CellIndex{Axis: Row, CellIndex: uint(i), AxisIndex: y})
+		tree.Push(data[i], CellIndex{CellIndex: uint(i), AxisIndex: y})
 	}
 
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(y))
@@ -214,7 +214,7 @@ func (ds *dataSquare) computeColumnProof(x uint, y uint) ([]byte, [][]byte, uint
 	data := ds.Column(y)
 
 	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], CellIndex{Axis: Col, CellIndex: uint(i), AxisIndex: y})
+		tree.Push(data[i], CellIndex{CellIndex: uint(i), AxisIndex: y})
 	}
 	// TODO(ismail): check for overflow when casting from uint -> int
 	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(x))

--- a/tree.go
+++ b/tree.go
@@ -40,7 +40,7 @@ func NewDefaultTree() Tree {
 	}
 }
 
-func (d *DefaultTree) Push(data []byte, idx CellIndex) {
+func (d *DefaultTree) Push(data []byte, _idx CellIndex) {
 	// ignore the idx, as this implementation doesn't need that info
 	d.leaves = append(d.leaves, data)
 }

--- a/tree.go
+++ b/tree.go
@@ -10,19 +10,26 @@ import (
 // TreeConstructorFn creates a fresh Tree instance to be used as the Merkle inside of rsmt2d.
 type TreeConstructorFn = func() Tree
 
+// Axis indicates whether a Column or Row is being used
 type Axis bool
 
 const (
+	// Row indicates the use of the x axis of a data square
 	Row Axis = true
+
+	// Col indicates the use of the y axis of a data square
 	Col Axis = false
 )
 
+// CellIndex contains all information needed to identify the cell that is being
+// pushed
 type CellIndex struct {
 	AxisIndex uint
 	CellIndex uint
 	Axis      Axis
 }
 
+// Tree wraps merkle tree implementations to work with rsmt2d
 type Tree interface {
 	Push(data []byte, idx CellIndex)
 	// TODO(ismail): is this general enough?

--- a/tree.go
+++ b/tree.go
@@ -10,16 +10,15 @@ import (
 // TreeConstructorFn creates a fresh Tree instance to be used as the Merkle inside of rsmt2d.
 type TreeConstructorFn = func() Tree
 
-// CellIndex contains all information needed to identify the cell that is being
+// SquareIndex contains all information needed to identify the cell that is being
 // pushed
-type CellIndex struct {
-	AxisIndex uint
-	CellIndex uint
+type SquareIndex struct {
+	Axis, Cell uint
 }
 
 // Tree wraps merkle tree implementations to work with rsmt2d
 type Tree interface {
-	Push(data []byte, idx CellIndex)
+	Push(data []byte, idx SquareIndex)
 	// TODO(ismail): is this general enough?
 	Prove(idx int) (merkleRoot []byte, proofSet [][]byte, proofIndex uint64, numLeaves uint64)
 	Root() []byte
@@ -40,7 +39,7 @@ func NewDefaultTree() Tree {
 	}
 }
 
-func (d *DefaultTree) Push(data []byte, _idx CellIndex) {
+func (d *DefaultTree) Push(data []byte, _idx SquareIndex) {
 	// ignore the idx, as this implementation doesn't need that info
 	d.leaves = append(d.leaves, data)
 }

--- a/tree.go
+++ b/tree.go
@@ -10,23 +10,11 @@ import (
 // TreeConstructorFn creates a fresh Tree instance to be used as the Merkle inside of rsmt2d.
 type TreeConstructorFn = func() Tree
 
-// Axis indicates whether a Column or Row is being used
-type Axis bool
-
-const (
-	// Row indicates the use of the x axis of a data square
-	Row Axis = true
-
-	// Col indicates the use of the y axis of a data square
-	Col Axis = false
-)
-
 // CellIndex contains all information needed to identify the cell that is being
 // pushed
 type CellIndex struct {
 	AxisIndex uint
 	CellIndex uint
-	Axis      Axis
 }
 
 // Tree wraps merkle tree implementations to work with rsmt2d

--- a/tree.go
+++ b/tree.go
@@ -46,7 +46,7 @@ func NewDefaultTree() Tree {
 }
 
 func (d *DefaultTree) Push(data []byte, idx CellIndex) {
-	// ignore the idx, as this implementation doesn't need know
+	// ignore the idx, as this implementation doesn't need that info
 	d.leaves = append(d.leaves, data)
 }
 

--- a/tree.go
+++ b/tree.go
@@ -10,8 +10,21 @@ import (
 // TreeConstructorFn creates a fresh Tree instance to be used as the Merkle inside of rsmt2d.
 type TreeConstructorFn = func() Tree
 
+type Axis bool
+
+const (
+	Row Axis = true
+	Col Axis = false
+)
+
+type CellIndex struct {
+	AxisIndex uint
+	CellIndex uint
+	Axis      Axis
+}
+
 type Tree interface {
-	Push(data []byte)
+	Push(data []byte, idx CellIndex)
 	// TODO(ismail): is this general enough?
 	Prove(idx int) (merkleRoot []byte, proofSet [][]byte, proofIndex uint64, numLeaves uint64)
 	Root() []byte
@@ -32,7 +45,8 @@ func NewDefaultTree() Tree {
 	}
 }
 
-func (d *DefaultTree) Push(data []byte) {
+func (d *DefaultTree) Push(data []byte, idx CellIndex) {
+	// ignore the idx, as this implementation doesn't need know
 	d.leaves = append(d.leaves, data)
 }
 


### PR DESCRIPTION
This PR modifies the `Tree` interface to pass along the information needed to identify which cell is being pushed.

closes #19 