### PR TITLE
code hygiene: idiomatic error naming

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -2,6 +2,7 @@ package rsmt2d
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"gonum.org/v1/gonum/mat"
@@ -11,6 +12,9 @@ const (
 	row    = 0
 	column = 1
 )
+
+// ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
+var ErrUnrepairableDataSquare = errors.New("failed to solve data square")
 
 // ErrByzantineRow is thrown when there is a repaired row does not match the expected row merkle root.
 type ErrByzantineRow struct {
@@ -28,14 +32,6 @@ type ErrByzantineColumn struct {
 
 func (e *ErrByzantineColumn) Error() string {
 	return fmt.Sprintf("byzantine column: %d", e.ColumnNumber)
-}
-
-// UnrepairableDataSquareError is thrown when there is insufficient chunks to repair the square.
-type UnrepairableDataSquareError struct {
-}
-
-func (e *UnrepairableDataSquareError) Error() string {
-	return "failed to solve data square"
 }
 
 // RepairExtendedDataSquare repairs an incomplete extended data square, against its expected row and column merkle roots.
@@ -61,7 +57,7 @@ func RepairExtendedDataSquare(
 	}
 
 	if chunkSize == 0 {
-		return nil, &UnrepairableDataSquareError{}
+		return nil, ErrUnrepairableDataSquare
 	}
 
 	fillerChunk := bytes.Repeat([]byte{0}, chunkSize)
@@ -210,7 +206,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 		if solved {
 			break
 		} else if !progressMade {
-			return &UnrepairableDataSquareError{}
+			return ErrUnrepairableDataSquare
 		}
 	}
 

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -2,6 +2,7 @@ package rsmt2d
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,14 +63,14 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
 		}
 
-		var ok bool
 		corrupted, err = original.deepCopy()
 		if err != nil {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%v", err, codec)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
-		if err, ok = err.(*ErrByzantineRow); !ok {
+		var byzRow *ErrByzantineRow
+		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
 		}
 
@@ -79,7 +80,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
-		if err, ok = err.(*ErrByzantineRow); !ok {
+		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
 		}
 
@@ -91,7 +92,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
-		if err, ok = err.(*ErrByzantineColumn); !ok {
+		var byzColumn *ErrByzantineColumn
+		if !errors.As(err, &byzColumn) {
 			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
 		}
 
@@ -103,7 +105,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
-		if err, ok = err.(*ErrByzantineColumn); !ok {
+		if !errors.As(err, &byzColumn) {
 			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
 		}
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -69,8 +69,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 0, corruptChunk)
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
-		if err, ok = err.(*ByzantineRowError); !ok {
-			t.Errorf("did not return a ByzantineRowError for a bad row; got: %v", err)
+		if err, ok = err.(*ErrByzantineRow); !ok {
+			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
 		}
 
 		corrupted, err = original.deepCopy()
@@ -79,8 +79,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corrupted.setCell(0, 3, corruptChunk)
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
-		if err, ok = err.(*ByzantineRowError); !ok {
-			t.Errorf("did not return a ByzantineRowError for a bad row; got %v", err)
+		if err, ok = err.(*ErrByzantineRow); !ok {
+			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy()
@@ -91,8 +91,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
-		if err, ok = err.(*ByzantineColumnError); !ok {
-			t.Errorf("did not return a ByzantineColumnError for a bad column; got %v", err)
+		if err, ok = err.(*ErrByzantineColumn); !ok {
+			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy()
@@ -103,8 +103,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
-		if err, ok = err.(*ByzantineColumnError); !ok {
-			t.Errorf("did not return a ByzantineColumnError for a bad column; got %v", err)
+		if err, ok = err.(*ErrByzantineColumn); !ok {
+			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
 		}
 	}
 }


### PR DESCRIPTION
I've spend some time looking into refactoring and cleaning up rsmt2d. This is the first of a few smaller PRs in this direction:
- prefix errors with `Err`
- remove tracking EDS in errors