### PR TITLE
CI: use arm64 instead of arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goarch: ["arm", "amd64"]
+        goarch: ["arm64", "amd64"]
     timeout-minutes: 5
     steps:
       - uses: actions/setup-go@v2
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goarch: ["arm", "amd64"]
+        goarch: ["arm64", "amd64"]
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
We have no plans of supporting 32-bit architectures, so should use `arm64` instead of `arm`. `arm` also doesn't have `-race` checking.