### PR TITLE
Benchmark repair with 1/4 instead of 1/2 of shares

### DIFF
--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -125,8 +125,8 @@ func BenchmarkRepair(b *testing.B) {
 			}
 
 			flattened := eds.flattened()
-			// Randomly remove half the shares
-			for i := 0; i < i*i*2; {
+			// Randomly remove 3/4 of the shares
+			for i := 0; i < i*i*3; {
 				ind := rand.Intn(i)
 				if len(flattened[ind]) == 0 {
 					continue


### PR DESCRIPTION
Remove 3/4 of shares for repair benchmark to test with the minimum number of shares needed.