### PR TITLE
Add mem benchmark command to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ Experimental software. Use at your own risk!
 Run benchmarks
 
 ```sh
-go test -tags leopard -bench=.
+go test -tags leopard -benchmem -bench=.
 ```


### PR DESCRIPTION
Benchmarking allocations will be important with upcoming optimization attempts, so add `-benchmem` to benchmark command in readme to be clearer.