### PR TITLE
Fix repair benchmark

### DIFF
--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -124,15 +124,16 @@ func BenchmarkRepair(b *testing.B) {
 				b.Error(err)
 			}
 
-			flattened := eds.flattened()
-			// Randomly remove 3/4 of the shares
-			for j := 0; j < i*i*3; {
-				ind := rand.Intn(j + 1)
-				if flattened[ind] == nil {
-					continue
+			// Randomly remove 1/2 of the shares of each row
+			for r := 0; r < i*2; {
+				for c := 0; c < i; {
+					ind := rand.Intn(i + 1)
+					if eds.Cell(uint(r), uint(ind)) == nil {
+						continue
+					}
+					eds.setCell(uint(r), uint(ind), nil)
+					c++
 				}
-				flattened[ind] = nil
-				j++
 			}
 
 			b.Run(
@@ -141,7 +142,7 @@ func BenchmarkRepair(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						_, err := RepairExtendedDataSquare(eds.RowRoots(),
 							eds.ColumnRoots(),
-							flattened,
+							eds.flattened(),
 							_codecType,
 							NewDefaultTree,
 						)

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -127,7 +127,7 @@ func BenchmarkRepair(b *testing.B) {
 			flattened := eds.flattened()
 			// Randomly remove 3/4 of the shares
 			for j := 0; j < i*i*3; {
-				ind := rand.Intn(j)
+				ind := rand.Intn(j + 1)
 				if len(flattened[ind]) == 0 {
 					continue
 				}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -124,14 +124,15 @@ func BenchmarkRepair(b *testing.B) {
 				b.Error(err)
 			}
 
+			flattened := eds.flattened()
 			// Randomly remove 1/2 of the shares of each row
 			for r := 0; r < i*2; {
 				for c := 0; c < i; {
 					ind := rand.Intn(i + 1)
-					if eds.Cell(uint(r), uint(ind)) == nil {
+					if flattened[r*i+ind] == nil {
 						continue
 					}
-					eds.setCell(uint(r), uint(ind), nil)
+					flattened[r*i+ind] = nil
 					c++
 				}
 			}
@@ -142,7 +143,7 @@ func BenchmarkRepair(b *testing.B) {
 					for n := 0; n < b.N; n++ {
 						_, err := RepairExtendedDataSquare(eds.RowRoots(),
 							eds.ColumnRoots(),
-							eds.flattened(),
+							flattened,
 							_codecType,
 							NewDefaultTree,
 						)

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -126,7 +126,7 @@ func BenchmarkRepair(b *testing.B) {
 
 			flattened := eds.flattened()
 			// Randomly remove 3/4 of the shares
-			for i := 0; i < i*i*3; {
+			for i := 0; i < i*i*2*3; {
 				ind := rand.Intn(i)
 				if len(flattened[ind]) == 0 {
 					continue

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -128,10 +128,10 @@ func BenchmarkRepair(b *testing.B) {
 			// Randomly remove 3/4 of the shares
 			for j := 0; j < i*i*3; {
 				ind := rand.Intn(j + 1)
-				if len(flattened[ind]) == 0 {
+				if flattened[ind] == nil {
 					continue
 				}
-				flattened[ind] = []byte{}
+				flattened[ind] = nil
 				j++
 			}
 

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -126,13 +126,13 @@ func BenchmarkRepair(b *testing.B) {
 
 			flattened := eds.flattened()
 			// Randomly remove 3/4 of the shares
-			for i := 0; i < i*i*2*3; {
-				ind := rand.Intn(i)
+			for j := 0; j < i*i*3; {
+				ind := rand.Intn(j)
 				if len(flattened[ind]) == 0 {
 					continue
 				}
 				flattened[ind] = []byte{}
-				i++
+				j++
 			}
 
 			b.Run(

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -126,7 +126,7 @@ func BenchmarkRepair(b *testing.B) {
 
 			flattened := eds.flattened()
 			// Randomly remove 1/2 of the shares of each row
-			for r := 0; r < i*2; {
+			for r := 0; r < i*2; r++ {
 				for c := 0; c < i; {
 					ind := rand.Intn(i + 1)
 					if flattened[r*i+ind] == nil {

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -141,7 +141,8 @@ func BenchmarkRepair(b *testing.B) {
 				fmt.Sprintf("Repairing %dx%d ODS using %s", i, i, _codecType),
 				func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
-						_, err := RepairExtendedDataSquare(eds.RowRoots(),
+						_, err := RepairExtendedDataSquare(
+							eds.RowRoots(),
 							eds.ColumnRoots(),
 							flattened,
 							_codecType,


### PR DESCRIPTION
Fix repair to properly drop shares. It now drops exactly half from each row, to guarantee that the square can be repaired. @evan-forbes noted that there are corner cases where the square isn't repairable with <1/2 the EDS's shares (e.g. if only the first rows in their entirety are present).