### PR TITLE
Return uncorrupted EDS from repair, and optimize

### DIFF
--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -85,6 +85,7 @@ func RepairExtendedDataSquare(
 }
 
 func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][]byte, bitMask bitMatrix) error {
+	// TODO(john): re-add eds
 	// Keep repeating until the square is solved
 	solved := false
 	for {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -272,21 +272,21 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(rowRoots [][]byte, columnRoo
 		}
 
 		if rowIsComplete {
-			shares, err = Encode(eds.rowSlice(i, 0, eds.originalDataWidth), eds.codec)
+			parityShares, err := Encode(eds.rowSlice(i, 0, eds.originalDataWidth), eds.codec)
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(flattenChunks(shares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
+			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
 				return &ErrByzantineRow{i}
 			}
 		}
 
 		if colIsComplete {
-			shares, err = Encode(eds.columnSlice(0, i, eds.originalDataWidth), eds.codec)
+			parityShares, err := Encode(eds.columnSlice(0, i, eds.originalDataWidth), eds.codec)
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(flattenChunks(shares), flattenChunks(eds.columnSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
+			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.columnSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
 				return &ErrByzantineColumn{i}
 			}
 		}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -148,10 +148,18 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 						if err != nil {
 							return err
 						}
-						rebuiltShares = append(rebuiltShares[0:eds.originalDataWidth], rebuiltExtendedShares...)
+						startIndex := len(rebuiltExtendedShares) - int(eds.originalDataWidth)
+						rebuiltShares = append(
+							rebuiltShares[0:eds.originalDataWidth],
+							rebuiltExtendedShares[startIndex:]...,
+						)
 					} else {
 						// Otherwise copy them from the EDS.
-						rebuiltShares = append(rebuiltShares[0:eds.originalDataWidth], shares[eds.originalDataWidth:]...)
+						startIndex := len(shares) - int(eds.originalDataWidth)
+						rebuiltShares = append(
+							rebuiltShares[0:eds.originalDataWidth],
+							shares[startIndex:]...,
+						)
 					}
 
 					// Check that rebuilt shares matches appropriate root

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -85,7 +85,6 @@ func RepairExtendedDataSquare(
 }
 
 func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][]byte, bitMask bitMatrix) error {
-	// TODO(john): re-add eds
 	// Keep repeating until the square is solved
 	solved := false
 	for {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -215,34 +215,44 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 }
 
 func (eds *ExtendedDataSquare) verifyRoots(rowRoots [][]byte, columnRoots [][]byte, mode int, i uint) error {
-	if mode == row {
+	switch mode {
+	case row:
 		if !bytes.Equal(eds.RowRoot(i), rowRoots[i]) {
 			return &ErrByzantineRow{i}
 		}
-	} else if mode == column {
+	case column:
 		if !bytes.Equal(eds.ColRoot(i), columnRoots[i]) {
 			return &ErrByzantineColumn{i}
 		}
+	default:
+		panic(fmt.Sprintf("invalid mode %d", mode))
 	}
 	return nil
 }
 
 func (eds *ExtendedDataSquare) rebuildExtendedPart(mode int, rowOrColIdx uint) error {
 	var data [][]byte
-	if mode == row {
+	switch mode {
+	case row:
 		data = eds.rowSlice(rowOrColIdx, 0, eds.originalDataWidth)
-	} else if mode == column {
+	case column:
 		data = eds.columnSlice(0, rowOrColIdx, eds.originalDataWidth)
+
+	default:
+		panic(fmt.Sprintf("invalid mode %d", mode))
 	}
 	rebuiltExtendedShares, err := Encode(data, eds.codec)
 	if err != nil {
 		return err
 	}
 	for p, s := range rebuiltExtendedShares {
-		if mode == row {
+		switch mode {
+		case row:
 			eds.setCell(rowOrColIdx, eds.originalDataWidth+uint(p), s)
-		} else if mode == column {
+		case column:
 			eds.setCell(eds.originalDataWidth+uint(p), rowOrColIdx, s)
+		default:
+			panic(fmt.Sprintf("invalid mode %d", mode))
 		}
 	}
 

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -154,27 +154,30 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 					}
 
 					// Check that rebuilt shares matches appropriate root
-					root, err := eds.verifyAgainstRoots(rowRoots, columnRoots, mode, uint(i), rebuiltShares)
+					_, err = eds.verifyAgainstRoots(rowRoots, columnRoots, mode, uint(i), rebuiltShares)
 					if err != nil {
 						return err
 					}
 
 					// Check that newly completed orthogonal vectors match their new merkle roots
-					// TODO
 					for j := 0; j < int(eds.width); j++ {
 						switch mode {
 						case row:
 							if !bitMask.Get(i, j) &&
-								bitMask.ColumnIsOne(j) &&
-								!bytes.Equal(eds.ColRoot(uint(j)), columnRoots[j]) {
-								return &ErrByzantineColumn{uint(j)}
+								bitMask.ColumnIsOne(j) {
+								_, err := eds.verifyAgainstRoots(rowRoots, columnRoots, column, uint(j), rebuiltShares)
+								if err != nil {
+									return &ErrByzantineColumn{uint(j)}
+								}
 							}
 
 						case column:
 							if !bitMask.Get(j, i) &&
-								bitMask.RowIsOne(j) &&
-								!bytes.Equal(eds.RowRoot(uint(j)), rowRoots[j]) {
-								return &ErrByzantineRow{uint(j)}
+								bitMask.RowIsOne(j) {
+								_, err := eds.verifyAgainstRoots(rowRoots, columnRoots, row, uint(j), rebuiltShares)
+								if err != nil {
+									return &ErrByzantineRow{uint(j)}
+								}
 							}
 
 						default:

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -144,7 +144,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 
 					if isExtendedPartIncomplete {
 						// If needed, rebuild the parity shares too.
-						rebuiltExtendedShares, err := Encode(rebuiltShares, eds.codec)
+						rebuiltExtendedShares, err := Encode(rebuiltShares[0:eds.originalDataWidth], eds.codec)
 						if err != nil {
 							return err
 						}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -151,7 +151,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 						rebuiltShares = append(rebuiltShares, rebuiltExtendedShares...)
 					} else {
 						// Otherwise copy them from the EDS.
-						rebuiltShares = append(rebuiltShares, shares[eds.width:]...)
+						rebuiltShares = append(rebuiltShares, shares[eds.originalDataWidth:]...)
 					}
 
 					// Check that rebuilt shares matches appropriate root

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -237,12 +237,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 }
 
 func (eds *ExtendedDataSquare) verifyAgainstRoots(rowRoots [][]byte, columnRoots [][]byte, mode int, i uint, shares [][]byte) error {
-	tree := eds.createTreeFn()
-	for cell, d := range shares {
-		tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
-	}
-
-	root := tree.Root()
+	root := eds.computeSharesRoot(shares, i)
 
 	switch mode {
 	case row:
@@ -286,12 +281,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(rowRoots [][]byte, columnRoo
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
-				tree := eds.createTreeFn()
-				for cell, d := range parityShares {
-					tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
-				}
-				root := tree.Root()
-
+				root := eds.computeSharesRoot(parityShares, i)
 				return &ErrByzantineRow{i, root, parityShares}
 			}
 		}
@@ -302,12 +292,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(rowRoots [][]byte, columnRoo
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.columnSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				tree := eds.createTreeFn()
-				for cell, d := range parityShares {
-					tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
-				}
-				root := tree.Root()
-
+				root := eds.computeSharesRoot(parityShares, i)
 				return &ErrByzantineColumn{i, root, parityShares}
 			}
 		}
@@ -323,4 +308,12 @@ func noMissingData(input [][]byte) bool {
 		}
 	}
 	return true
+}
+
+func (eds *ExtendedDataSquare) computeSharesRoot(shares [][]byte, i uint) []byte {
+	tree := eds.createTreeFn()
+	for cell, d := range shares {
+		tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
+	}
+	return tree.Root()
 }

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -37,8 +37,20 @@ func (e *ErrByzantineColumn) Error() string {
 	return fmt.Sprintf("byzantine column: %d", e.ColumnNumber)
 }
 
-// RepairExtendedDataSquare repairs an incomplete extended data square, against its expected row and column merkle roots.
+// RepairExtendedDataSquare attempts to repair an incomplete extended data
+// square (EDS), comparing repaired rows and columns against expected Merkle
+// roots.
+//
+// Input
+//
 // Missing data chunks should be represented as nil.
+//
+// Output
+//
+// The EDS is modified in-place. If repairing is successful, the EDS will be
+// complete. If repairing is unsuccessful, the EDS will be the most-repaired
+// prior to the Byzantine row or column being repaired, and the repaired
+// Byzantine row or column is returned in the error.
 func RepairExtendedDataSquare(
 	rowRoots [][]byte,
 	columnRoots [][]byte,

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -95,7 +95,6 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
 			for mode := range []int{row, column} {
-
 				var isIncomplete bool
 				var isExtendedPartIncomplete bool
 				switch mode {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -144,10 +144,11 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 
 					if isExtendedPartIncomplete {
 						// If needed, rebuild the parity shares too.
-						rebuiltShares, err = Encode(rebuiltShares, eds.codec)
+						rebuiltExtendedShares, err := Encode(rebuiltShares, eds.codec)
 						if err != nil {
 							return err
 						}
+						rebuiltShares = append(rebuiltShares, rebuiltExtendedShares...)
 					} else {
 						// Otherwise copy them from the EDS.
 						rebuiltShares = append(rebuiltShares, shares[eds.width:]...)

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -15,22 +15,22 @@ const (
 // ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
 var ErrUnrepairableDataSquare = errors.New("failed to solve data square")
 
-// ErrByzantineRow is thrown when there is a repaired row does not match the expected row merkle root.
+// ErrByzantineRow is thrown when there is a repaired row does not match the expected row Merkle root.
 type ErrByzantineRow struct {
-	RowNumber uint
-	Root      []byte
-	Shares    [][]byte
+	RowNumber uint     // Row index
+	Root      []byte   // Merkle root of repaired row
+	Shares    [][]byte // Repaired row shares
 }
 
 func (e *ErrByzantineRow) Error() string {
 	return fmt.Sprintf("byzantine row: %d", e.RowNumber)
 }
 
-// ErrByzantineColumn is thrown when there is a repaired column does not match the expected column merkle root.
+// ErrByzantineColumn is thrown when there is a repaired column does not match the expected column Merkle root.
 type ErrByzantineColumn struct {
-	ColumnNumber uint
-	Root         []byte
-	Shares       [][]byte
+	ColumnNumber uint     // Column index
+	Root         []byte   // Merkle root of repaired column
+	Shares       [][]byte // Repaired column shares
 }
 
 func (e *ErrByzantineColumn) Error() string {

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -148,10 +148,10 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 						if err != nil {
 							return err
 						}
-						rebuiltShares = append(rebuiltShares, rebuiltExtendedShares...)
+						rebuiltShares = append(rebuiltShares[0:eds.originalDataWidth], rebuiltExtendedShares...)
 					} else {
 						// Otherwise copy them from the EDS.
-						rebuiltShares = append(rebuiltShares, shares[eds.originalDataWidth:]...)
+						rebuiltShares = append(rebuiltShares[0:eds.originalDataWidth], shares[eds.originalDataWidth:]...)
 					}
 
 					// Check that rebuilt shares matches appropriate root

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -230,13 +230,13 @@ func (eds *ExtendedDataSquare) verifyRoots(rowRoots [][]byte, columnRoots [][]by
 	return nil
 }
 
-func (eds *ExtendedDataSquare) rebuildExtendedPart(mode int, rowOrColIdx uint) error {
+func (eds *ExtendedDataSquare) rebuildExtendedPart(mode int, i uint) error {
 	var data [][]byte
 	switch mode {
 	case row:
-		data = eds.rowSlice(rowOrColIdx, 0, eds.originalDataWidth)
+		data = eds.rowSlice(i, 0, eds.originalDataWidth)
 	case column:
-		data = eds.columnSlice(0, rowOrColIdx, eds.originalDataWidth)
+		data = eds.columnSlice(0, i, eds.originalDataWidth)
 
 	default:
 		panic(fmt.Sprintf("invalid mode %d", mode))
@@ -248,9 +248,9 @@ func (eds *ExtendedDataSquare) rebuildExtendedPart(mode int, rowOrColIdx uint) e
 	for p, s := range rebuiltExtendedShares {
 		switch mode {
 		case row:
-			eds.setCell(rowOrColIdx, eds.originalDataWidth+uint(p), s)
+			eds.setCell(i, eds.originalDataWidth+uint(p), s)
 		case column:
-			eds.setCell(eds.originalDataWidth+uint(p), rowOrColIdx, s)
+			eds.setCell(eds.originalDataWidth+uint(p), i, s)
 		default:
 			panic(fmt.Sprintf("invalid mode %d", mode))
 		}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -249,8 +249,6 @@ func (eds *ExtendedDataSquare) verifyAgainstRoots(rowRoots [][]byte, columnRoots
 }
 
 func (eds *ExtendedDataSquare) prerepairSanityCheck(rowRoots [][]byte, columnRoots [][]byte, bitMask bitMatrix) error {
-	var shares [][]byte
-	var err error
 	for i := uint(0); i < eds.width; i++ {
 		rowIsComplete := bitMask.RowIsOne(int(i))
 		colIsComplete := bitMask.ColumnIsOne(int(i))

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -113,20 +113,20 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 					shares := make([][]byte, eds.width)
 					for j := 0; j < int(eds.width); j++ {
 						var vectorData [][]byte
-						var rowIdx, colIdx int
+						var r, c int
 						switch mode {
 						case row:
-							rowIdx = i
-							colIdx = j
+							r = i
+							c = j
 							vectorData = eds.Row(uint(i))
 						case column:
-							rowIdx = j
-							colIdx = i
+							r = j
+							c = i
 							vectorData = eds.Column(uint(i))
 						default:
 							panic(fmt.Sprintf("invalid mode %d", mode))
 						}
-						if bitMask.Get(rowIdx, colIdx) {
+						if bitMask.Get(r, c) {
 							// As guaranteed by the bitMask, vectorData can't be nil here:
 							shares[j] = vectorData[j]
 						}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -162,7 +162,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 					}
 
 					// Check that rebuilt shares matches appropriate root
-					_, err = eds.verifyAgainstRoots(rowRoots, columnRoots, mode, uint(i), rebuiltShares)
+					err = eds.verifyAgainstRoots(rowRoots, columnRoots, mode, uint(i), rebuiltShares)
 					if err != nil {
 						return err
 					}
@@ -173,7 +173,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 						case row:
 							if !bitMask.Get(i, j) &&
 								bitMask.ColumnIsOne(j) {
-								_, err := eds.verifyAgainstRoots(rowRoots, columnRoots, column, uint(j), rebuiltShares)
+								err := eds.verifyAgainstRoots(rowRoots, columnRoots, column, uint(j), rebuiltShares)
 								if err != nil {
 									return &ErrByzantineColumn{uint(j)}
 								}
@@ -182,7 +182,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 						case column:
 							if !bitMask.Get(j, i) &&
 								bitMask.RowIsOne(j) {
-								_, err := eds.verifyAgainstRoots(rowRoots, columnRoots, row, uint(j), rebuiltShares)
+								err := eds.verifyAgainstRoots(rowRoots, columnRoots, row, uint(j), rebuiltShares)
 								if err != nil {
 									return &ErrByzantineRow{uint(j)}
 								}
@@ -232,7 +232,7 @@ func (eds *ExtendedDataSquare) solveCrossword(rowRoots [][]byte, columnRoots [][
 	return nil
 }
 
-func (eds *ExtendedDataSquare) verifyAgainstRoots(rowRoots [][]byte, columnRoots [][]byte, mode int, i uint, shares [][]byte) ([]byte, error) {
+func (eds *ExtendedDataSquare) verifyAgainstRoots(rowRoots [][]byte, columnRoots [][]byte, mode int, i uint, shares [][]byte) error {
 	tree := eds.createTreeFn()
 	for cell, d := range shares {
 		tree.Push(d, SquareIndex{Cell: uint(cell), Axis: i})
@@ -243,16 +243,16 @@ func (eds *ExtendedDataSquare) verifyAgainstRoots(rowRoots [][]byte, columnRoots
 	switch mode {
 	case row:
 		if !bytes.Equal(root, rowRoots[i]) {
-			return nil, &ErrByzantineRow{i}
+			return &ErrByzantineRow{i}
 		}
 	case column:
 		if !bytes.Equal(root, columnRoots[i]) {
-			return nil, &ErrByzantineColumn{i}
+			return &ErrByzantineColumn{i}
 		}
 	default:
 		panic(fmt.Sprintf("invalid mode %d", mode))
 	}
-	return root, nil
+	return nil
 }
 
 func (eds *ExtendedDataSquare) prerepairSanityCheck(rowRoots [][]byte, columnRoots [][]byte, bitMask bitMatrix) error {


### PR DESCRIPTION
Fixes #25.

Optimizes repair logic to do work on a so-far correct EDS struct, and only modify it when modifications are guaranteed to not corrupt.

Note that the original implementation did a quadratic amount of work (deep copy of the entire square) each iteration, for a quadratic number of iterations (i.e. `O(n^4)`). This implementation does linear work (process a single row or column) each iteration, for a quadratic number of iterations (i.e `O(n^3)`). To my understanding, this is order-optimal.

## Initial Results

Bench with `edsBackup` re-added as before #24 against `master` branch as of start of this PR:
```
goos: linux
goarch: amd64
pkg: github.com/lazyledger/rsmt2d
cpu: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-4         	     261	   4228503 ns/op	 3644160 B/op	   11333 allocs/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-4         	      61	  19182579 ns/op	16971170 B/op	   42245 allocs/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-4         	      14	  79352834 ns/op	61468033 B/op	  159749 allocs/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-4       	       1	1495244230 ns/op	2933171416 B/op	 1094336 allocs/op
```

Bench without `edsBackup` logic (`master` branch as of the start of this PR):
```
goos: linux
goarch: amd64
pkg: github.com/lazyledger/rsmt2d
cpu: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-4         	     277	   4127613 ns/op	 3644169 B/op	   11333 allocs/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-4         	      61	  19092464 ns/op	16971164 B/op	   42245 allocs/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-4         	      14	  78191005 ns/op	61468040 B/op	  159749 allocs/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-4       	       3	 381096647 ns/op	284551544 B/op	  620037 allocs/op
```

We see that removing the deep copy of the EDS at each iteration makes a huge difference at the largest square size. Minor-to-no difference at smaller square sizes. This is mostly within expectations.

Note that the current maximum ODS is 64x64, not 128x128, though that limit is expected to be raised either before mainnet or not too long thereafter.

## Optimized Results

Bench with optimized EDS backup logic:

```
goos: linux
goarch: amd64
pkg: github.com/lazyledger/rsmt2d
cpu: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-4         	     273	   4292978 ns/op	 3644160 B/op	   11333 allocs/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-4         	      61	  19140366 ns/op	16971166 B/op	   42245 allocs/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-4         	      14	  77965243 ns/op	61468058 B/op	  159749 allocs/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-4       	       3	 376856007 ns/op	284551544 B/op	  620037 allocs/op
```

We see that the optimized version performs the same as the version without EDS deep copies.