### PR TITLE
Refactor Codec API to allow for thread safe operation of the infectious RSGF8

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -13,21 +11,15 @@ var (
 	decodedDataDump [][]byte
 )
 
-func TestCodec_String(t *testing.T) {
-	for codec := range codecs {
-		assert.NotEqual(t, "", codec.String())
-	}
-}
-
 func BenchmarkEncoding(b *testing.B) {
 	// generate some fake data
 	data := generateRandData(128)
-	for _codecType := range codecs {
+	for codecName, codec := range codecs {
 		b.Run(
-			fmt.Sprintf("Encoding 128 shares using %s", _codecType),
+			fmt.Sprintf("Encoding 128 shares using %s", codecName),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
-					encodedData, err := Encode(data, _codecType)
+					encodedData, err := codec.Encode(data)
 					if err != nil {
 						b.Error(err)
 					}
@@ -53,13 +45,13 @@ func generateRandData(count int) [][]byte {
 
 func BenchmarkDecoding(b *testing.B) {
 	// generate some fake data
-	for codecType := range codecs {
-		data := generateMissingData(128, codecType)
+	for codecName, codec := range codecs {
+		data := generateMissingData(128, codec)
 		b.Run(
-			fmt.Sprintf("Decoding 128 shares using %s", codecType),
+			fmt.Sprintf("Decoding 128 shares using %s", codecName),
 			func(b *testing.B) {
 				for n := 0; n < b.N; n++ {
-					encodedData, err := Decode(data, codecType)
+					encodedData, err := codec.Decode(data)
 					if err != nil {
 						b.Error(err)
 					}
@@ -70,9 +62,9 @@ func BenchmarkDecoding(b *testing.B) {
 	}
 }
 
-func generateMissingData(count int, codecType CodecType) [][]byte {
+func generateMissingData(count int, codec Codec) [][]byte {
 	randData := generateRandData(count)
-	encoded, err := Encode(randData, codecType)
+	encoded, err := codec.Encode(randData)
 	if err != nil {
 		panic(err)
 	}

--- a/codecs.go
+++ b/codecs.go
@@ -30,12 +30,12 @@ func NewLeoRSFF16Codec() Codec {
 	if codec, has := codecs[LeopardFF16]; has {
 		return codec
 	}
-	panic("cannot use codec LeopardFF16 without 'leopard' build tag")
+	panic("cannot use codec LeopardFF16 without the 'leopard' build tag")
 }
 
 func NewLeoRSFF8Codec() Codec {
 	if codec, has := codecs[LeopardFF8]; has {
 		return codec
 	}
-	panic("cannot use codec LeopardFF8 without 'leopard' build tag")
+	panic("cannot use codec LeopardFF8 without the 'leopard' build tag")
 }

--- a/codecs.go
+++ b/codecs.go
@@ -11,7 +11,6 @@ const (
 type Codec interface {
 	Encode(data [][]byte) ([][]byte, error)
 	Decode(data [][]byte) ([][]byte, error)
-	New() Codec
 	// maxChunks returns the max. number of chunks each code supports in a 2D square.
 	maxChunks() int
 }

--- a/codecs.go
+++ b/codecs.go
@@ -1,63 +1,41 @@
 package rsmt2d
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
-// codecType type
-type CodecType int
-
-// Erasure codes enum:
 const (
-	// RSGF8 represents Reed-Solomon codecType with an 8-bit Finite Galois Field (2^8)
-	RSGF8 CodecType = iota
-	LeopardFF8
-	LeopardFF16
+	LeopardFF16 = "LeopardFF16"
+	LeopardFF8  = "LeopardFF8"
+	RSGF8       = "RSFG8"
 )
-
-func (c CodecType) String() string {
-	switch c {
-	case RSGF8:
-		return "RSGF8"
-	case LeopardFF8:
-		return "LeopardFF8"
-	case LeopardFF16:
-		return "LeopardFF16"
-	default:
-		return "UNSUPPORTED CODEC TYPE"
-	}
-}
 
 type Codec interface {
-	encode(data [][]byte) ([][]byte, error)
-	decode(data [][]byte) ([][]byte, error)
-	codecType() CodecType
+	Encode(data [][]byte) ([][]byte, error)
+	Decode(data [][]byte) ([][]byte, error)
+	New() Codec
 	// maxChunks returns the max. number of chunks each code supports in a 2D square.
 	maxChunks() int
 }
 
-var codecs = make(map[CodecType]Codec)
+// codecs is a global map used for keeping track of which codecs are included during testing
+var codecs = make(map[string]Codec)
 
-func registerCodec(ct CodecType, codec Codec) {
+func registerCodec(ct string, codec Codec) {
 	if codecs[ct] != nil {
 		panic(fmt.Sprintf("%v already registered", codec))
 	}
 	codecs[ct] = codec
 }
 
-func Encode(data [][]byte, codec CodecType) ([][]byte, error) {
-	if codec, ok := codecs[codec]; !ok {
-		return nil, errors.New("invalid codec")
-	} else {
-		return codec.encode(data)
+func NewLeoRSFF16Codec() Codec {
+	if codec, has := codecs[LeopardFF16]; has {
+		return codec
 	}
+	panic("cannot use codec LeopardFF16 without 'leopard' build tag")
 }
 
-func Decode(data [][]byte, codec CodecType) ([][]byte, error) {
-	if codec, ok := codecs[codec]; !ok {
-		return nil, errors.New("invalid codec")
-	} else {
-		return codec.decode(data)
+func NewLeoRSFF8Codec() Codec {
+	if codec, has := codecs[LeopardFF8]; has {
+		return codec
 	}
+	panic("cannot use codec LeopardFF8 without 'leopard' build tag")
 }

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -10,17 +10,12 @@ import (
 type ExtendedDataSquare struct {
 	*dataSquare
 	originalDataWidth uint
-	codec             CodecType
 }
 
 // ComputeExtendedDataSquare computes the extended data square for some chunks of data.
-func ComputeExtendedDataSquare(data [][]byte, codecType CodecType, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
-	if codec, ok := codecs[codecType]; !ok {
-		return nil, errors.New("unsupported codecType")
-	} else {
-		if len(data) > codec.maxChunks() {
-			return nil, errors.New("number of chunks exceeds the maximum")
-		}
+func ComputeExtendedDataSquare(data [][]byte, codec Codec, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
+	if len(data) > codec.maxChunks() {
+		return nil, errors.New("number of chunks exceeds the maximum")
 	}
 
 	ds, err := newDataSquare(data, treeCreatorFn)
@@ -28,8 +23,8 @@ func ComputeExtendedDataSquare(data [][]byte, codecType CodecType, treeCreatorFn
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codecType}
-	err = eds.erasureExtendSquare()
+	eds := ExtendedDataSquare{dataSquare: ds}
+	err = eds.erasureExtendSquare(codec)
 	if err != nil {
 		return nil, err
 	}
@@ -38,20 +33,17 @@ func ComputeExtendedDataSquare(data [][]byte, codecType CodecType, treeCreatorFn
 }
 
 // ImportExtendedDataSquare imports an extended data square, represented as flattened chunks of data.
-func ImportExtendedDataSquare(data [][]byte, codecType CodecType, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
-	if codec, ok := codecs[codecType]; !ok {
-		return nil, errors.New("unsupported codecType")
-	} else {
-		if len(data) > 4*codec.maxChunks() {
-			return nil, errors.New("number of chunks exceeds the maximum")
-		}
+func ImportExtendedDataSquare(data [][]byte, codec Codec, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
+	if len(data) > 4*codec.maxChunks() {
+		return nil, errors.New("number of chunks exceeds the maximum")
 	}
+
 	ds, err := newDataSquare(data, treeCreatorFn)
 	if err != nil {
 		return nil, err
 	}
 
-	eds := ExtendedDataSquare{dataSquare: ds, codec: codecType}
+	eds := ExtendedDataSquare{dataSquare: ds}
 	if eds.width%2 != 0 {
 		return nil, errors.New("square width must be even")
 	}
@@ -61,7 +53,7 @@ func ImportExtendedDataSquare(data [][]byte, codecType CodecType, treeCreatorFn 
 	return &eds, nil
 }
 
-func (eds *ExtendedDataSquare) erasureExtendSquare() error {
+func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 	eds.originalDataWidth = eds.width
 	if err := eds.extendSquare(eds.width, bytes.Repeat([]byte{0}, int(eds.chunkSize))); err != nil {
 		return err
@@ -82,7 +74,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare() error {
 	//  -------
 	for i := uint(0); i < eds.originalDataWidth; i++ {
 		// Extend horizontally
-		shares, err = Encode(eds.rowSlice(i, 0, eds.originalDataWidth), eds.codec)
+		shares, err = codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
 		if err != nil {
 			return err
 		}
@@ -91,7 +83,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare() error {
 		}
 
 		// Extend vertically
-		shares, err = Encode(eds.columnSlice(0, i, eds.originalDataWidth), eds.codec)
+		shares, err = codec.Encode(eds.columnSlice(0, i, eds.originalDataWidth))
 		if err != nil {
 			return err
 		}
@@ -112,7 +104,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare() error {
 	//  ------- -------
 	for i := eds.originalDataWidth; i < eds.width; i++ {
 		// Extend horizontally
-		shares, err = Encode(eds.rowSlice(i, 0, eds.originalDataWidth), eds.codec)
+		shares, err = codec.Encode(eds.rowSlice(i, 0, eds.originalDataWidth))
 		if err != nil {
 			return err
 		}
@@ -124,7 +116,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare() error {
 	return nil
 }
 
-func (eds *ExtendedDataSquare) deepCopy() (ExtendedDataSquare, error) {
-	eds, err := ImportExtendedDataSquare(eds.flattened(), eds.codec, eds.createTreeFn)
+func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error) {
+	eds, err := ImportExtendedDataSquare(eds.flattened(), codec, eds.createTreeFn)
 	return *eds, err
 }

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestComputeExtendedDataSquare(t *testing.T) {
-	codec := codecs[RSGF8].codecType()
+	codec := NewRSGF8Codec()
 	result, err := ComputeExtendedDataSquare([][]byte{
 		{1}, {2},
 		{3}, {4},
@@ -32,18 +32,14 @@ var dump *ExtendedDataSquare
 
 // BenchmarkExtension benchmarks extending datasquares sizes 4-128 using all supported codecs
 func BenchmarkExtension(b *testing.B) {
-	var codecTypes []CodecType
-	for codec := range codecs {
-		codecTypes = append(codecTypes, codec)
-	}
 	for i := 4; i < 129; i *= 2 {
-		for _, _codecType := range codecTypes {
+		for codecName, codec := range codecs {
 			square := genRandDS(i)
 			b.Run(
-				fmt.Sprintf("%s size %d", _codecType, i),
+				fmt.Sprintf("%s size %d", codecName, i),
 				func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
-						eds, err := ComputeExtendedDataSquare(square, _codecType, NewDefaultTree)
+						eds, err := ComputeExtendedDataSquare(square, codec, NewDefaultTree)
 						if err != nil {
 							b.Error(err)
 						}

--- a/infectiousRSGF8.go
+++ b/infectiousRSGF8.go
@@ -7,18 +7,20 @@ import (
 var _ Codec = &rsGF8Codec{}
 
 func init() {
-	registerCodec(RSGF8, newRSGF8Codec())
+	registerCodec("RSGF8", NewRSGF8Codec())
 }
 
 type rsGF8Codec struct {
 	infectiousCache map[int]*infectious.FEC
 }
 
-func newRSGF8Codec() *rsGF8Codec {
+// NewRSGF8Codec issues a new cached RSGF8Codec
+func NewRSGF8Codec() *rsGF8Codec {
 	return &rsGF8Codec{make(map[int]*infectious.FEC)}
 }
 
-func (c *rsGF8Codec) encode(data [][]byte) ([][]byte, error) {
+// Encode uses uses the infectous RSGF8 codec to encode the provided data
+func (c *rsGF8Codec) Encode(data [][]byte) ([][]byte, error) {
 	var fec *infectious.FEC
 	var err error
 	if value, ok := c.infectiousCache[len(data)]; ok {
@@ -46,7 +48,9 @@ func (c *rsGF8Codec) encode(data [][]byte) ([][]byte, error) {
 
 	return shares, err
 }
-func (c *rsGF8Codec) decode(data [][]byte) ([][]byte, error) {
+
+// Decode uses uses the infectous RSGF8 codec to decode the provided data
+func (c *rsGF8Codec) Decode(data [][]byte) ([][]byte, error) {
 	var fec *infectious.FEC
 	var err error
 	if value, ok := c.infectiousCache[len(data)/2]; ok {
@@ -76,8 +80,10 @@ func (c *rsGF8Codec) decode(data [][]byte) ([][]byte, error) {
 	return rebuiltShares, err
 }
 
-func (c *rsGF8Codec) codecType() CodecType {
-	return RSGF8
+// New is used to create a fresh cached RSGF8 cached codec. This is necessary
+// for thread safe operation
+func (c *rsGF8Codec) New() Codec {
+	return NewRSGF8Codec()
 }
 
 // maxChunks returns the max. number of chunks each code supports in a 2D square.

--- a/infectiousRSGF8.go
+++ b/infectiousRSGF8.go
@@ -80,12 +80,6 @@ func (c *rsGF8Codec) Decode(data [][]byte) ([][]byte, error) {
 	return rebuiltShares, err
 }
 
-// New is used to create a fresh cached RSGF8 cached codec. This is necessary
-// for thread safe operation
-func (c *rsGF8Codec) New() Codec {
-	return NewRSGF8Codec()
-}
-
 // maxChunks returns the max. number of chunks each code supports in a 2D square.
 func (c *rsGF8Codec) maxChunks() int {
 	return 128 * 128

--- a/leopard.go
+++ b/leopard.go
@@ -17,17 +17,17 @@ func init() {
 
 type leoRSFF8Codec struct{}
 
-func (l leoRSFF8Codec) encode(data [][]byte) ([][]byte, error) {
+func (l leoRSFF8Codec) Encode(data [][]byte) ([][]byte, error) {
 	return leopard.Encode(data)
 }
 
-func (l leoRSFF8Codec) decode(data [][]byte) ([][]byte, error) {
+func (l leoRSFF8Codec) Decode(data [][]byte) ([][]byte, error) {
 	half := len(data) / 2
 	return leopard.Decode(data[:half], data[half:])
 }
 
-func (l leoRSFF8Codec) codecType() CodecType {
-	return LeopardFF8
+func (l leoRSFF8Codec) New() Codec {
+	return newLeoRSFF8Codec()
 }
 
 func (l leoRSFF8Codec) maxChunks() int {
@@ -40,17 +40,17 @@ func newLeoRSFF8Codec() leoRSFF8Codec {
 
 type leoRSFF16Codec struct{}
 
-func (leo leoRSFF16Codec) encode(data [][]byte) ([][]byte, error) {
+func (leo leoRSFF16Codec) Encode(data [][]byte) ([][]byte, error) {
 	return leopard.Encode(data)
 }
 
-func (leo leoRSFF16Codec) decode(data [][]byte) ([][]byte, error) {
+func (leo leoRSFF16Codec) Decode(data [][]byte) ([][]byte, error) {
 	half := len(data) / 2
 	return leopard.Decode(data[:half], data[half:])
 }
 
-func (leo leoRSFF16Codec) codecType() CodecType {
-	return LeopardFF16
+func (leo leoRSFF16Codec) New() Codec {
+	return newLeoRSFF16Codec()
 }
 
 func (leo leoRSFF16Codec) maxChunks() int {

--- a/leopard.go
+++ b/leopard.go
@@ -26,10 +26,6 @@ func (l leoRSFF8Codec) Decode(data [][]byte) ([][]byte, error) {
 	return leopard.Decode(data[:half], data[half:])
 }
 
-func (l leoRSFF8Codec) New() Codec {
-	return newLeoRSFF8Codec()
-}
-
 func (l leoRSFF8Codec) maxChunks() int {
 	return 128 * 128
 }
@@ -47,10 +43,6 @@ func (leo leoRSFF16Codec) Encode(data [][]byte) ([][]byte, error) {
 func (leo leoRSFF16Codec) Decode(data [][]byte) ([][]byte, error) {
 	half := len(data) / 2
 	return leopard.Decode(data[:half], data[half:])
-}
-
-func (leo leoRSFF16Codec) New() Codec {
-	return newLeoRSFF16Codec()
 }
 
 func (leo leoRSFF16Codec) maxChunks() int {


### PR DESCRIPTION
This PR refactors the `Codec` api to a more typical go interface, while still maintaining separation of the leopard library using the leopard build tag. This Allows for the RSGF8 codec to be used in a thread safe fashion.