### PR TITLE
Single allocation `flattenChunks`

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,13 @@
 package rsmt2d
 
 func flattenChunks(chunks [][]byte) []byte {
-	flattened := chunks[0]
-	for _, chunk := range chunks[1:] {
+	length := 0
+	for _, chunk := range chunks {
+		length += len(chunk)
+	}
+
+	flattened := make([]byte, 0, length)
+	for _, chunk := range chunks {
 		flattened = append(flattened, chunk...)
 	}
 


### PR DESCRIPTION
Fixes #39. Refactor `flattenChunks` to only do a single allocation.

Bench before
<details>
<summary>Click to expand</summary>

```
goos: linux
goarch: amd64
pkg: github.com/lazyledger/rsmt2d
cpu: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
BenchmarkEncoding/Encoding_128_shares_using_RSGF8-4         	    5236	    210436 ns/op	   84224 B/op	     143 allocs/op
BenchmarkDecoding/Decoding_128_shares_using_RSGF8-4         	   47823	     24837 ns/op	   50552 B/op	      83 allocs/op
BenchmarkRoots/Square_Size_32x32-4                          	 1572390	       759.9 ns/op	    1536 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_64x64-4                          	  769806	      1584 ns/op	    3072 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_128x128-4                        	  440851	      2704 ns/op	    6144 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_256x256-4                        	  255529	      4549 ns/op	   12288 B/op	       2 allocs/op
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-4           	     279	   4217252 ns/op	 3644147 B/op	   11333 allocs/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-4           	      61	  19367582 ns/op	16971126 B/op	   42245 allocs/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-4           	      14	  78897378 ns/op	61468073 B/op	  159749 allocs/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-4         	       3	 382714118 ns/op	284551536 B/op	  620037 allocs/op
BenchmarkExtension/RSGF8_size_4-4                           	   71698	     16408 ns/op	   37904 B/op	     116 allocs/op
BenchmarkExtension/RSGF8_size_8-4                           	   12378	     93443 ns/op	  235184 B/op	     392 allocs/op
BenchmarkExtension/RSGF8_size_16-4                          	    2298	    495794 ns/op	  936947 B/op	    1256 allocs/op
BenchmarkExtension/RSGF8_size_32-4                          	     370	   3153520 ns/op	 4441722 B/op	    4328 allocs/op
BenchmarkExtension/RSGF8_size_64-4                          	      62	  17031171 ns/op	16354166 B/op	   15176 allocs/op
BenchmarkExtension/RSGF8_size_128-4                         	       9	 123199396 ns/op	74634650 B/op	   56072 allocs/op
```
</details>

Bench after
<details>
<summary>Click to expand</summary>

```
goos: linux
goarch: amd64
pkg: github.com/lazyledger/rsmt2d
cpu: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
BenchmarkEncoding/Encoding_128_shares_using_RSGF8-4         	    5529	    197073 ns/op	   35968 B/op	     131 allocs/op
BenchmarkDecoding/Decoding_128_shares_using_RSGF8-4         	   48978	     24626 ns/op	   50552 B/op	      83 allocs/op
BenchmarkRoots/Square_Size_32x32-4                          	 1493703	       777.3 ns/op	    1536 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_64x64-4                          	  800448	      1510 ns/op	    3072 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_128x128-4                        	  446007	      2707 ns/op	    6144 B/op	       2 allocs/op
BenchmarkRoots/Square_Size_256x256-4                        	  261134	      4541 ns/op	   12288 B/op	       2 allocs/op
BenchmarkRepair/Repairing_16x16_ODS_using_RSGF8-4           	     320	   3729502 ns/op	 1727217 B/op	   10181 allocs/op
BenchmarkRepair/Repairing_32x32_ODS_using_RSGF8-4           	      72	  16738736 ns/op	 6403442 B/op	   38789 allocs/op
BenchmarkRepair/Repairing_64x64_ODS_using_RSGF8-4           	      16	  71047294 ns/op	24604017 B/op	  151301 allocs/op
BenchmarkRepair/Repairing_128x128_ODS_using_RSGF8-4         	       3	 349952886 ns/op	99740016 B/op	  598533 allocs/op
BenchmarkExtension/RSGF8_size_4-4                           	   72462	     14276 ns/op	   31760 B/op	     104 allocs/op
BenchmarkExtension/RSGF8_size_8-4                           	   18405	     64210 ns/op	  118448 B/op	     296 allocs/op
BenchmarkExtension/RSGF8_size_16-4                          	    3166	    353010 ns/op	  457712 B/op	     968 allocs/op
BenchmarkExtension/RSGF8_size_32-4                          	     524	   2237355 ns/op	 1799800 B/op	    3464 allocs/op
BenchmarkExtension/RSGF8_size_64-4                          	      73	  14751181 ns/op	 7138165 B/op	   13064 allocs/op
BenchmarkExtension/RSGF8_size_128-4                         	       9	 113364116 ns/op	28431728 B/op	   50696 allocs/op
```
</details>

Benchstat
<details>
<summary>Click to expand</summary>

```
name                                        old time/op    new time/op    delta
Encoding/Encoding_128_shares_using_RSGF8-4     210µs ± 0%     197µs ± 0%   -6.35%  (p=1.000 n=1+1)
Decoding/Decoding_128_shares_using_RSGF8-4    24.8µs ± 0%    24.6µs ± 0%   -0.85%  (p=1.000 n=1+1)
Roots/Square_Size_32x32-4                      760ns ± 0%     777ns ± 0%   +2.29%  (p=1.000 n=1+1)
Roots/Square_Size_64x64-4                     1.58µs ± 0%    1.51µs ± 0%   -4.67%  (p=1.000 n=1+1)
Roots/Square_Size_128x128-4                   2.70µs ± 0%    2.71µs ± 0%   +0.11%  (p=1.000 n=1+1)
Roots/Square_Size_256x256-4                   4.55µs ± 0%    4.54µs ± 0%   -0.18%  (p=1.000 n=1+1)
Repair/Repairing_16x16_ODS_using_RSGF8-4      4.22ms ± 0%    3.73ms ± 0%  -11.57%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-4      19.4ms ± 0%    16.7ms ± 0%  -13.57%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-4      78.9ms ± 0%    71.0ms ± 0%   -9.95%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-4     383ms ± 0%     350ms ± 0%   -8.56%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-4                      16.4µs ± 0%    14.3µs ± 0%  -12.99%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-4                      93.4µs ± 0%    64.2µs ± 0%  -31.28%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-4                      496µs ± 0%     353µs ± 0%  -28.80%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-4                     3.15ms ± 0%    2.24ms ± 0%  -29.05%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-4                     17.0ms ± 0%    14.8ms ± 0%  -13.39%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-4                     123ms ± 0%     113ms ± 0%   -7.98%  (p=1.000 n=1+1)

name                                        old alloc/op   new alloc/op   delta
Encoding/Encoding_128_shares_using_RSGF8-4    84.2kB ± 0%    36.0kB ± 0%  -57.29%  (p=1.000 n=1+1)
Decoding/Decoding_128_shares_using_RSGF8-4    50.6kB ± 0%    50.6kB ± 0%     ~     (all equal)
Roots/Square_Size_32x32-4                     1.54kB ± 0%    1.54kB ± 0%     ~     (all equal)
Roots/Square_Size_64x64-4                     3.07kB ± 0%    3.07kB ± 0%     ~     (all equal)
Roots/Square_Size_128x128-4                   6.14kB ± 0%    6.14kB ± 0%     ~     (all equal)
Roots/Square_Size_256x256-4                   12.3kB ± 0%    12.3kB ± 0%     ~     (all equal)
Repair/Repairing_16x16_ODS_using_RSGF8-4      3.64MB ± 0%    1.73MB ± 0%  -52.60%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-4      17.0MB ± 0%     6.4MB ± 0%  -62.27%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-4      61.5MB ± 0%    24.6MB ± 0%  -59.97%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-4     285MB ± 0%     100MB ± 0%  -64.95%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-4                      37.9kB ± 0%    31.8kB ± 0%  -16.21%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-4                       235kB ± 0%     118kB ± 0%  -49.64%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-4                      937kB ± 0%     458kB ± 0%  -51.15%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-4                     4.44MB ± 0%    1.80MB ± 0%  -59.48%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-4                     16.4MB ± 0%     7.1MB ± 0%  -56.35%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-4                    74.6MB ± 0%    28.4MB ± 0%  -61.91%  (p=1.000 n=1+1)

name                                        old allocs/op  new allocs/op  delta
Encoding/Encoding_128_shares_using_RSGF8-4       143 ± 0%       131 ± 0%   -8.39%  (p=1.000 n=1+1)
Decoding/Decoding_128_shares_using_RSGF8-4      83.0 ± 0%      83.0 ± 0%     ~     (all equal)
Roots/Square_Size_32x32-4                       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_64x64-4                       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_128x128-4                     2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_256x256-4                     2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Repair/Repairing_16x16_ODS_using_RSGF8-4       11.3k ± 0%     10.2k ± 0%  -10.17%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-4       42.2k ± 0%     38.8k ± 0%   -8.18%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-4        160k ± 0%      151k ± 0%   -5.29%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-4      620k ± 0%      599k ± 0%   -3.47%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-4                         116 ± 0%       104 ± 0%  -10.34%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-4                         392 ± 0%       296 ± 0%  -24.49%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-4                      1.26k ± 0%     0.97k ± 0%  -22.93%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-4                      4.33k ± 0%     3.46k ± 0%  -19.96%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-4                      15.2k ± 0%     13.1k ± 0%  -13.92%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-4                     56.1k ± 0%     50.7k ± 0%   -9.59%  (p=1.000 n=1+1)
```
</details>