### PR TITLE
Fix repair bench to re-initialize shares

### DIFF
--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -153,18 +153,6 @@ func BenchmarkRepair(b *testing.B) {
 			}
 
 			extendedDataWidth := originalDataWidth * 2
-			flattened := eds.flattened()
-			// Randomly remove 1/2 of the shares of each row
-			for r := 0; r < extendedDataWidth; r++ {
-				for c := 0; c < originalDataWidth; {
-					ind := rand.Intn(extendedDataWidth)
-					if flattened[r*extendedDataWidth+ind] == nil {
-						continue
-					}
-					flattened[r*extendedDataWidth+ind] = nil
-					c++
-				}
-			}
 
 			b.Run(
 				fmt.Sprintf(
@@ -175,6 +163,23 @@ func BenchmarkRepair(b *testing.B) {
 				),
 				func(b *testing.B) {
 					for n := 0; n < b.N; n++ {
+						b.StopTimer()
+
+						flattened := eds.flattened()
+						// Randomly remove 1/2 of the shares of each row
+						for r := 0; r < extendedDataWidth; r++ {
+							for c := 0; c < originalDataWidth; {
+								ind := rand.Intn(extendedDataWidth)
+								if flattened[r*extendedDataWidth+ind] == nil {
+									continue
+								}
+								flattened[r*extendedDataWidth+ind] = nil
+								c++
+							}
+						}
+
+						b.StartTimer()
+
 						_, err := RepairExtendedDataSquare(
 							eds.RowRoots(),
 							eds.ColumnRoots(),


### PR DESCRIPTION
The repair benchmark was re-using repaired shares, resulting in only a single run of the actual repairing following by `b.N` runs of just checking that the repaired shares are correct. Fix to actually re-initialize the missing shares on each run.

Depends on #49.