### PR TITLE
Optimization: store duplicate rows and columns

### DIFF
--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -11,7 +11,7 @@ func TestNewDataSquare(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if !reflect.DeepEqual(result.square, [][][]byte{{{1, 2}}}) {
+	if !reflect.DeepEqual(result.squareRow, [][][]byte{{{1, 2}}}) {
 		t.Errorf("newDataSquare failed for 1x1 square")
 	}
 
@@ -19,7 +19,7 @@ func TestNewDataSquare(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if !reflect.DeepEqual(result.square, [][][]byte{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}) {
+	if !reflect.DeepEqual(result.squareRow, [][][]byte{{{1, 2}, {3, 4}}, {{5, 6}, {7, 8}}}) {
 		t.Errorf("newDataSquare failed for 2x2 square")
 	}
 
@@ -52,7 +52,7 @@ func TestExtendSquare(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if !reflect.DeepEqual(ds.square, [][][]byte{{{1, 2}, {0, 0}}, {{0, 0}, {0, 0}}}) {
+	if !reflect.DeepEqual(ds.squareRow, [][][]byte{{{1, 2}, {0, 0}}, {{0, 0}, {0, 0}}}) {
 		t.Errorf("extendSquare failed; unexpected result when extending 1x1 square to 2x2 square")
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -45,10 +45,10 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected err while repairing data square: %v, codec: :%v", err, codec)
 		} else {
-			assert.Equal(t, result.square[0][0], ones)
-			assert.Equal(t, result.square[0][1], twos)
-			assert.Equal(t, result.square[1][0], threes)
-			assert.Equal(t, result.square[1][1], fours)
+			assert.Equal(t, result.Cell(0, 0), ones)
+			assert.Equal(t, result.Cell(0, 1), twos)
+			assert.Equal(t, result.Cell(1, 0), threes)
+			assert.Equal(t, result.Cell(1, 1), fours)
 		}
 
 		flattened = original.flattened()

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -78,7 +78,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		if err != nil {
 			return err
 		}
-		if err := eds.setRowSlice(i, eds.originalDataWidth, shares); err != nil {
+		if err := eds.setRowSlice(i, eds.originalDataWidth, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 
@@ -87,7 +87,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		if err != nil {
 			return err
 		}
-		if err := eds.setColumnSlice(eds.originalDataWidth, i, shares); err != nil {
+		if err := eds.setColumnSlice(eds.originalDataWidth, i, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 	}
@@ -108,7 +108,7 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		if err != nil {
 			return err
 		}
-		if err := eds.setRowSlice(i, eds.originalDataWidth, shares); err != nil {
+		if err := eds.setRowSlice(i, eds.originalDataWidth, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 	}

--- a/extendeddatasquare_test.go
+++ b/extendeddatasquare_test.go
@@ -16,7 +16,7 @@ func TestComputeExtendedDataSquare(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if !reflect.DeepEqual(result.square, [][][]byte{
+	if !reflect.DeepEqual(result.squareRow, [][][]byte{
 		{{1}, {2}, {7}, {13}},
 		{{3}, {4}, {13}, {31}},
 		{{5}, {14}, {19}, {41}},


### PR DESCRIPTION
Implements the second choice of optimization in https://github.com/lazyledger/rsmt2d/issues/39#issuecomment-817107324. Refactoring everything to go through `Call(row, col)` would be an astronomical amount of work, as e.g. encoding libraries expect simply `[][]byte` slices. This implementation increases memory footprint by ~2 for the data square, but non-trivially reduces runtime especially at larger square sizes, as returning slices is zero-allocation.

The `Repair` benchmarks below are most representative of real-world use, and see _increasing_ decreases in runtime as square size increases.

<details>
<summary>Click to expand</summary>

```
name                                        old time/op    new time/op    delta
Encoding/Encoding_128_shares_using_RSGF8-8     144µs ± 0%     145µs ± 0%   +0.15%  (p=1.000 n=1+1)
Decoding/Decoding_128_shares_using_RSGF8-8    30.1µs ± 0%    30.6µs ± 0%   +1.74%  (p=1.000 n=1+1)
Roots/Square_Size_32x32-8                      603ns ± 0%     612ns ± 0%   +1.46%  (p=1.000 n=1+1)
Roots/Square_Size_64x64-8                     1.31µs ± 0%    1.46µs ± 0%  +11.04%  (p=1.000 n=1+1)
Roots/Square_Size_128x128-8                   2.08µs ± 0%    2.20µs ± 0%   +5.87%  (p=1.000 n=1+1)
Roots/Square_Size_256x256-8                   3.56µs ± 0%    3.79µs ± 0%   +6.64%  (p=1.000 n=1+1)
Repair/Repairing_16x16_ODS_using_RSGF8-8      3.60ms ± 0%    3.32ms ± 0%   -7.78%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-8      17.4ms ± 0%    14.8ms ± 0%  -15.04%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-8      80.0ms ± 0%    63.6ms ± 0%  -20.45%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-8     419ms ± 0%     312ms ± 0%  -25.70%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-8                      12.1µs ± 0%    12.7µs ± 0%   +4.94%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-8                      50.8µs ± 0%    53.0µs ± 0%   +4.34%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-8                      275µs ± 0%     283µs ± 0%   +3.07%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-8                     1.70ms ± 0%    1.73ms ± 0%   +1.71%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-8                     10.8ms ± 0%    10.8ms ± 0%   -0.37%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-8                    74.3ms ± 0%    74.6ms ± 0%   +0.35%  (p=1.000 n=1+1)

name                                        old alloc/op   new alloc/op   delta
Encoding/Encoding_128_shares_using_RSGF8-8    36.0kB ± 0%    36.0kB ± 0%     ~     (all equal)
Decoding/Decoding_128_shares_using_RSGF8-8    50.6kB ± 0%    50.6kB ± 0%     ~     (all equal)
Roots/Square_Size_32x32-8                     1.54kB ± 0%    1.54kB ± 0%     ~     (all equal)
Roots/Square_Size_64x64-8                     3.07kB ± 0%    3.07kB ± 0%     ~     (all equal)
Roots/Square_Size_128x128-8                   6.14kB ± 0%    6.14kB ± 0%     ~     (all equal)
Roots/Square_Size_256x256-8                   12.3kB ± 0%    12.3kB ± 0%     ~     (all equal)
Repair/Repairing_16x16_ODS_using_RSGF8-8      2.51MB ± 0%    1.78MB ± 0%  -29.28%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-8      12.9MB ± 0%     6.8MB ± 0%  -47.14%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-8      76.9MB ± 0%    27.1MB ± 0%  -64.76%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-8     514MB ± 0%     115MB ± 0%  -77.64%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-8                      31.8kB ± 0%    33.6kB ± 0%   +5.84%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-8                       118kB ± 0%     125kB ± 0%   +5.70%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-8                      458kB ± 0%     483kB ± 0%   +5.63%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-8                     1.80MB ± 0%    1.90MB ± 0%   +5.59%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-8                     7.14MB ± 0%    7.54MB ± 0%   +5.57%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-8                    28.4MB ± 0%    30.0MB ± 0%   +5.56%  (p=1.000 n=1+1)

name                                        old allocs/op  new allocs/op  delta
Encoding/Encoding_128_shares_using_RSGF8-8       131 ± 0%       131 ± 0%     ~     (all equal)
Decoding/Decoding_128_shares_using_RSGF8-8      83.0 ± 0%      83.0 ± 0%     ~     (all equal)
Roots/Square_Size_32x32-8                       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_64x64-8                       2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_128x128-8                     2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Roots/Square_Size_256x256-8                     2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Repair/Repairing_16x16_ODS_using_RSGF8-8       12.9k ± 0%     11.9k ± 0%   -7.42%  (p=1.000 n=1+1)
Repair/Repairing_32x32_ODS_using_RSGF8-8       49.4k ± 0%     45.4k ± 0%   -8.09%  (p=1.000 n=1+1)
Repair/Repairing_64x64_ODS_using_RSGF8-8        192k ± 0%      176k ± 0%   -8.51%  (p=1.000 n=1+1)
Repair/Repairing_128x128_ODS_using_RSGF8-8      760k ± 0%      698k ± 0%   -8.23%  (p=1.000 n=1+1)
Extension/RSGF8_size_4-8                         104 ± 0%       114 ± 0%   +9.62%  (p=1.000 n=1+1)
Extension/RSGF8_size_8-8                         296 ± 0%       314 ± 0%   +6.08%  (p=1.000 n=1+1)
Extension/RSGF8_size_16-8                        968 ± 0%      1002 ± 0%   +3.51%  (p=1.000 n=1+1)
Extension/RSGF8_size_32-8                      3.46k ± 0%     3.53k ± 0%   +1.91%  (p=1.000 n=1+1)
Extension/RSGF8_size_64-8                      13.1k ± 0%     13.2k ± 0%   +1.00%  (p=1.000 n=1+1)
Extension/RSGF8_size_128-8                     50.7k ± 0%     51.0k ± 0%   +0.51%  (p=1.000 n=1+1)
```
</details>