### PR TITLE
Improve public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ func main() {
         // ComputeExtendedDataSquare failed
     }
 
-    // Save all shares in flattended form.
-    // Note: slices returned from Row() an Column() are read-only.
+    // Save all shares in flattened form.
     // If you need to write to them, copy first.
     flattened := make([][]byte, 0, eds.Width()*eds.Width())
     for i := uint(0); i < eds.Width(); i++ {

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
     fours := bytes.Repeat([]byte{4}, bufferSize)
 
     // Compute parity shares
-    eds, _ := rsmt2d.ComputeExtendedDataSquare(
+    eds, err := rsmt2d.ComputeExtendedDataSquare(
         [][]byte{
             ones, twos,
             threes, fours,
@@ -37,14 +37,16 @@ func main() {
         codec,
         rsmt2d.NewDefaultTree,
     )
+    if err != nil {
+        // ComputeExtendedDataSquare failed
+    }
 
     // Save all shares in flattended form.
     // Note: slices returned from Row() an Column() are read-only.
     // If you need to write to them, copy first.
     flattened := make([][]byte, 0, eds.Width()*eds.Width())
     for i := uint(0); i < eds.Width(); i++ {
-        startIndex := i * eds.Width()
-        copy(flattened[startIndex:startIndex+eds.Width()], eds.Row(i))
+        flattened = append(flattened, eds.Row(i)...)
     }
 
     // Delete some shares, just enough so that repairing is possible.
@@ -56,7 +58,7 @@ func main() {
     // Repair square.
     repaired, err := rsmt2d.RepairExtendedDataSquare(
         eds.RowRoots(),
-        eds.ColumnRoots(),
+        eds.ColRoots(),
         flattened,
         codec,
         rsmt2d.NewDefaultTree,

--- a/bit_matrix.go
+++ b/bit_matrix.go
@@ -29,7 +29,7 @@ func (bm *bitMatrix) Set(row, col int) {
 	bm.mask[idx/64] |= uint64(1) << uint(idx%64)
 }
 
-func (bm bitMatrix) ColumnIsOne(c int) bool {
+func (bm bitMatrix) ColIsOne(c int) bool {
 	for r := 0; r < bm.squareSize; r++ {
 		if !bm.Get(r, c) {
 			return false

--- a/bit_matrix_test.go
+++ b/bit_matrix_test.go
@@ -15,11 +15,11 @@ func Test_bitMatrix_ColRangeIsOne(t *testing.T) {
 		end   int
 	}
 	tests := []struct {
-		name          string
-		initParams    initParams
-		setBits       []int
-		rangeInColumn colRange
-		want          bool
+		name       string
+		initParams initParams
+		setBits    []int
+		rangeInCol colRange
+		want       bool
 	}{
 		{"empty", initParams{4, 16}, nil, colRange{0, 0, 4}, false},
 		{"empty", initParams{4, 16}, nil, colRange{1, 0, 4}, false},
@@ -44,14 +44,14 @@ func Test_bitMatrix_ColRangeIsOne(t *testing.T) {
 			for _, flatIdx := range tt.setBits {
 				bm.SetFlat(flatIdx)
 			}
-			if got := bm.ColRangeIsOne(tt.rangeInColumn.c, tt.rangeInColumn.start, tt.rangeInColumn.end); got != tt.want {
+			if got := bm.ColRangeIsOne(tt.rangeInCol.c, tt.rangeInCol.start, tt.rangeInCol.end); got != tt.want {
 				t.Errorf("ColRangeIsOne() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func Test_bitMatrix_ColumnIsOne(t *testing.T) {
+func Test_bitMatrix_ColIsOne(t *testing.T) {
 	type initParams struct {
 		squareSize int
 		bits       int
@@ -61,7 +61,7 @@ func Test_bitMatrix_ColumnIsOne(t *testing.T) {
 		name       string
 		initParams initParams
 		setBits    []int
-		column     int
+		col        int
 		want       bool
 	}{
 		{"empty", initParams{4, 16}, []int{}, 0, false},
@@ -95,8 +95,8 @@ func Test_bitMatrix_ColumnIsOne(t *testing.T) {
 			for _, flatIdx := range tt.setBits {
 				bm.SetFlat(flatIdx)
 			}
-			if got := bm.ColumnIsOne(tt.column); got != tt.want {
-				t.Errorf("ColumnIsOne() = %v, want %v", got, tt.want)
+			if got := bm.ColIsOne(tt.col); got != tt.want {
+				t.Errorf("ColIsOne() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -160,7 +160,7 @@ func Test_bitMatrix_NumOnesInCol(t *testing.T) {
 		name       string
 		initParams initParams
 		setBits    []int
-		column     int
+		col        int
 		want       int
 	}{
 		{"empty", initParams{4, 16}, []int{}, 0, 0},
@@ -187,7 +187,7 @@ func Test_bitMatrix_NumOnesInCol(t *testing.T) {
 			for _, flatIdx := range tt.setBits {
 				bm.SetFlat(flatIdx)
 			}
-			if got := bm.NumOnesInCol(tt.column); got != tt.want {
+			if got := bm.NumOnesInCol(tt.col); got != tt.want {
 				t.Errorf("NumOnesInCol() = %v, want %v", got, tt.want)
 			}
 		})

--- a/datasquare.go
+++ b/datasquare.go
@@ -242,8 +242,3 @@ func (ds *dataSquare) flattened() [][]byte {
 
 	return flattened
 }
-
-// getWidth returns the width of the square.
-func (ds *dataSquare) getWidth() uint {
-	return ds.width
-}

--- a/datasquare.go
+++ b/datasquare.go
@@ -14,7 +14,7 @@ type dataSquare struct {
 	width        uint
 	chunkSize    uint
 	rowRoots     [][]byte
-	columnRoots  [][]byte
+	colRoots     [][]byte
 	createTreeFn TreeConstructorFn
 }
 
@@ -127,26 +127,26 @@ func (ds *dataSquare) setRowSlice(x uint, y uint, newRow [][]byte) error {
 	return nil
 }
 
-func (ds *dataSquare) columnSlice(x uint, y uint, length uint) [][]byte {
+func (ds *dataSquare) colSlice(x uint, y uint, length uint) [][]byte {
 	return ds.squareCol[y][x : x+length]
 }
 
-// column returns a column slice.
+// col returns a column slice.
 // Do not modify this slice directly, instead use setCell.
-func (ds *dataSquare) column(y uint) [][]byte {
-	return ds.columnSlice(0, y, ds.width)
+func (ds *dataSquare) col(y uint) [][]byte {
+	return ds.colSlice(0, y, ds.width)
 }
 
-func (ds *dataSquare) setColumnSlice(x uint, y uint, newColumn [][]byte) error {
-	for i := uint(0); i < uint(len(newColumn)); i++ {
-		if len(newColumn[i]) != int(ds.chunkSize) {
+func (ds *dataSquare) setColSlice(x uint, y uint, newCol [][]byte) error {
+	for i := uint(0); i < uint(len(newCol)); i++ {
+		if len(newCol[i]) != int(ds.chunkSize) {
 			return errors.New("invalid chunk size")
 		}
 	}
 
-	for i := uint(0); i < uint(len(newColumn)); i++ {
-		ds.squareRow[x+i][y] = newColumn[i]
-		ds.squareCol[y][x+i] = newColumn[i]
+	for i := uint(0); i < uint(len(newCol)); i++ {
+		ds.squareRow[x+i][y] = newCol[i]
+		ds.squareCol[y][x+i] = newCol[i]
 	}
 
 	ds.resetRoots()
@@ -156,19 +156,19 @@ func (ds *dataSquare) setColumnSlice(x uint, y uint, newColumn [][]byte) error {
 
 func (ds *dataSquare) resetRoots() {
 	ds.rowRoots = nil
-	ds.columnRoots = nil
+	ds.colRoots = nil
 }
 
 func (ds *dataSquare) computeRoots() {
 	rowRoots := make([][]byte, ds.width)
-	columnRoots := make([][]byte, ds.width)
+	colRoots := make([][]byte, ds.width)
 	for i := uint(0); i < ds.width; i++ {
 		rowRoots[i] = ds.getRowRoot(i)
-		columnRoots[i] = ds.getColRoot(i)
+		colRoots[i] = ds.getColRoot(i)
 	}
 
 	ds.rowRoots = rowRoots
-	ds.columnRoots = columnRoots
+	ds.colRoots = colRoots
 }
 
 // getRowRoots returns the Merkle roots of all the rows in the square.
@@ -197,22 +197,22 @@ func (ds *dataSquare) getRowRoot(x uint) []byte {
 
 // getColRoots returns the Merkle roots of all the columns in the square.
 func (ds *dataSquare) getColRoots() [][]byte {
-	if ds.columnRoots == nil {
+	if ds.colRoots == nil {
 		ds.computeRoots()
 	}
 
-	return ds.columnRoots
+	return ds.colRoots
 }
 
 // getColRoot calculates and returns the root of the selected row. Note: unlike the
 // getColRoots method, getColRoot uses the built-in cache when available.
 func (ds *dataSquare) getColRoot(y uint) []byte {
-	if ds.columnRoots != nil {
-		return ds.columnRoots[y]
+	if ds.colRoots != nil {
+		return ds.colRoots[y]
 	}
 
 	tree := ds.createTreeFn()
-	for i, d := range ds.column(y) {
+	for i, d := range ds.col(y) {
 		tree.Push(d, SquareIndex{Axis: y, Cell: uint(i)})
 	}
 

--- a/datasquare.go
+++ b/datasquare.go
@@ -172,7 +172,6 @@ func (ds *dataSquare) computeRoots() {
 }
 
 // getRowRoots returns the Merkle roots of all the rows in the square.
-// Note: do not modify this slice directly, use setCell instead.
 func (ds *dataSquare) getRowRoots() [][]byte {
 	if ds.rowRoots == nil {
 		ds.computeRoots()
@@ -197,7 +196,6 @@ func (ds *dataSquare) getRowRoot(x uint) []byte {
 }
 
 // getColRoots returns the Merkle roots of all the columns in the square.
-// Note: do not modify this slice directly, use setCell instead.
 func (ds *dataSquare) getColRoots() [][]byte {
 	if ds.columnRoots == nil {
 		ds.computeRoots()

--- a/datasquare.go
+++ b/datasquare.go
@@ -221,30 +221,6 @@ func (ds *dataSquare) getColRoot(y uint) []byte {
 	return tree.Root()
 }
 
-func (ds *dataSquare) computeRowProof(x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
-	tree := ds.createTreeFn()
-	data := ds.row(x)
-
-	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], SquareIndex{Axis: y, Cell: uint(i)})
-	}
-
-	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(y))
-	return merkleRoot, proof, uint(proofIndex), uint(numLeaves), nil
-}
-
-func (ds *dataSquare) computeColumnProof(x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
-	tree := ds.createTreeFn()
-	data := ds.column(y)
-
-	for i := uint(0); i < ds.width; i++ {
-		tree.Push(data[i], SquareIndex{Axis: y, Cell: uint(i)})
-	}
-	// TODO(ismail): check for overflow when casting from uint -> int
-	merkleRoot, proof, proofIndex, numLeaves := tree.Prove(int(x))
-	return merkleRoot, proof, uint(proofIndex), uint(numLeaves), nil
-}
-
 // getCell returns a single chunk at a specific cell.
 func (ds *dataSquare) getCell(x uint, y uint) []byte {
 	cell := make([]byte, ds.chunkSize)

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -62,7 +62,7 @@ func TestRoots(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	if !reflect.DeepEqual(result.RowRoots(), result.ColumnRoots()) {
+	if !reflect.DeepEqual(result.getRowRoots(), result.getColRoots()) {
 		t.Errorf("computing roots failed; expecting row and column roots for 1x1 square to be equal")
 	}
 }
@@ -77,8 +77,8 @@ func TestLazyRootGeneration(t *testing.T) {
 	var colRoots [][]byte
 
 	for i := uint(0); i < square.width; i++ {
-		rowRoots = append(rowRoots, square.RowRoot(i))
-		colRoots = append(rowRoots, square.ColRoot(i))
+		rowRoots = append(rowRoots, square.getRowRoot(i))
+		colRoots = append(rowRoots, square.getColRoot(i))
 	}
 
 	square.computeRoots()
@@ -95,18 +95,18 @@ func TestRootAPI(t *testing.T) {
 	}
 
 	for i := uint(0); i < square.width; i++ {
-		if !reflect.DeepEqual(square.RowRoots()[i], square.RowRoot(i)) {
+		if !reflect.DeepEqual(square.getRowRoots()[i], square.getRowRoot(i)) {
 			t.Errorf(
 				"Row root API results in different roots, expected %v go %v",
-				square.RowRoots()[i],
-				square.RowRoot(i),
+				square.getRowRoots()[i],
+				square.getRowRoot(i),
 			)
 		}
-		if !reflect.DeepEqual(square.ColumnRoots()[i], square.ColRoot(i)) {
+		if !reflect.DeepEqual(square.getColRoots()[i], square.getColRoot(i)) {
 			t.Errorf(
 				"Column root API results in different roots, expected %v go %v",
-				square.ColumnRoots()[i],
-				square.ColRoot(i),
+				square.getColRoots()[i],
+				square.getColRoot(i),
 			)
 		}
 	}

--- a/datasquare_test.go
+++ b/datasquare_test.go
@@ -83,8 +83,8 @@ func TestLazyRootGeneration(t *testing.T) {
 
 	square.computeRoots()
 
-	if !reflect.DeepEqual(square.rowRoots, rowRoots) && !reflect.DeepEqual(square.columnRoots, colRoots) {
-		t.Error("RowRoot or ColumnRoot did not produce identical roots to computeRoots")
+	if !reflect.DeepEqual(square.rowRoots, rowRoots) && !reflect.DeepEqual(square.colRoots, colRoots) {
+		t.Error("getRowRoot or getColRoot did not produce identical roots to computeRoots")
 	}
 }
 
@@ -135,7 +135,7 @@ func TestDefaultTreeProofs(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	_, proof, proofIndex, numLeaves, err = computeColumnProof(result, 1, 1)
+	_, proof, proofIndex, numLeaves, err = computeColProof(result, 1, 1)
 	if err != nil {
 		t.Errorf("Got unexpected error: %v", err)
 	}
@@ -179,9 +179,9 @@ func computeRowProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, ui
 	return merkleRoot, proof, uint(proofIndex), uint(numLeaves), nil
 }
 
-func computeColumnProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
+func computeColProof(ds *dataSquare, x uint, y uint) ([]byte, [][]byte, uint, uint, error) {
 	tree := ds.createTreeFn()
-	data := ds.column(y)
+	data := ds.col(y)
 
 	for i := uint(0); i < ds.width; i++ {
 		tree.Push(data[i], SquareIndex{Axis: y, Cell: uint(i)})

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	row = iota
-	column
+	col
 )
 
 // ErrUnrepairableDataSquare is thrown when there is insufficient chunks to repair the square.
@@ -25,14 +25,14 @@ func (e *ErrByzantineRow) Error() string {
 	return fmt.Sprintf("byzantine row: %d", e.RowNumber)
 }
 
-// ErrByzantineColumn is thrown when a repaired column does not match the expected column Merkle root.
-type ErrByzantineColumn struct {
-	ColumnNumber uint     // Column index
-	Shares       [][]byte // Pre-repaired column shares. Missing shares are nil.
+// ErrByzantineCol is thrown when a repaired column does not match the expected column Merkle root.
+type ErrByzantineCol struct {
+	ColNumber uint     // Column index
+	Shares    [][]byte // Pre-repaired column shares. Missing shares are nil.
 }
 
-func (e *ErrByzantineColumn) Error() string {
-	return fmt.Sprintf("byzantine column: %d", e.ColumnNumber)
+func (e *ErrByzantineCol) Error() string {
+	return fmt.Sprintf("byzantine column: %d", e.ColNumber)
 }
 
 // RepairExtendedDataSquare attempts to repair an incomplete extended data
@@ -52,7 +52,7 @@ func (e *ErrByzantineColumn) Error() string {
 // nil.
 func RepairExtendedDataSquare(
 	rowRoots [][]byte,
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	data [][]byte,
 	codec Codec,
 	treeCreatorFn TreeConstructorFn,
@@ -86,12 +86,12 @@ func RepairExtendedDataSquare(
 		return nil, err
 	}
 
-	err = eds.prerepairSanityCheck(rowRoots, columnRoots, bitMat, codec)
+	err = eds.prerepairSanityCheck(rowRoots, colRoots, bitMat, codec)
 	if err != nil {
 		return nil, err
 	}
 
-	err = eds.solveCrossword(rowRoots, columnRoots, bitMat, codec)
+	err = eds.solveCrossword(rowRoots, colRoots, bitMat, codec)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func RepairExtendedDataSquare(
 // solveCrossword attempts to iteratively repair an EDS.
 func (eds *ExtendedDataSquare) solveCrossword(
 	rowRoots [][]byte,
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	bitMask bitMatrix,
 	codec Codec,
 ) error {
@@ -115,11 +115,11 @@ func (eds *ExtendedDataSquare) solveCrossword(
 
 		// Loop through every row and column, attempt to rebuild each row or column if incomplete
 		for i := 0; i < int(eds.width); i++ {
-			solvedRow, progressMadeRow, err := eds.solveCrosswordRow(i, rowRoots, columnRoots, bitMask, codec)
+			solvedRow, progressMadeRow, err := eds.solveCrosswordRow(i, rowRoots, colRoots, bitMask, codec)
 			if err != nil {
 				return err
 			}
-			solvedCol, progressMadeCol, err := eds.solveCrosswordCol(i, rowRoots, columnRoots, bitMask, codec)
+			solvedCol, progressMadeCol, err := eds.solveCrosswordCol(i, rowRoots, colRoots, bitMask, codec)
 			if err != nil {
 				return err
 			}
@@ -147,7 +147,7 @@ func (eds *ExtendedDataSquare) solveCrossword(
 func (eds *ExtendedDataSquare) solveCrosswordRow(
 	r int,
 	rowRoots [][]byte,
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	bitMask bitMatrix,
 	codec Codec,
 ) (bool, bool, error) {
@@ -186,8 +186,8 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 	// Check that newly completed orthogonal vectors match their new merkle roots
 	for c := 0; c < int(eds.width); c++ {
 		if !bitMask.Get(r, c) &&
-			bitMask.ColumnIsOne(c) {
-			err := eds.verifyAgainstColRoots(columnRoots, uint(c), bitMask, rebuiltShares)
+			bitMask.ColIsOne(c) {
+			err := eds.verifyAgainstColRoots(colRoots, uint(c), bitMask, rebuiltShares)
 			if err != nil {
 				return false, false, err
 			}
@@ -215,11 +215,11 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 func (eds *ExtendedDataSquare) solveCrosswordCol(
 	c int,
 	rowRoots [][]byte,
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	bitMask bitMatrix,
 	codec Codec,
 ) (bool, bool, error) {
-	isComplete := bitMask.ColumnIsOne(c)
+	isComplete := bitMask.ColIsOne(c)
 	if isComplete {
 		return true, false, nil
 	}
@@ -227,7 +227,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	// Prepare shares
 	shares := make([][]byte, eds.width)
 	for r := 0; r < int(eds.width); r++ {
-		vectorData := eds.column(uint(c))
+		vectorData := eds.col(uint(c))
 
 		if bitMask.Get(r, c) {
 			// As guaranteed by the bitMask, vectorData can't be nil here:
@@ -246,7 +246,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	}
 
 	// Check that rebuilt shares matches appropriate root
-	err = eds.verifyAgainstColRoots(columnRoots, uint(c), bitMask, rebuiltShares)
+	err = eds.verifyAgainstColRoots(colRoots, uint(c), bitMask, rebuiltShares)
 	if err != nil {
 		return false, false, err
 	}
@@ -330,19 +330,19 @@ func (eds *ExtendedDataSquare) verifyAgainstRowRoots(
 }
 
 func (eds *ExtendedDataSquare) verifyAgainstColRoots(
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	c uint, bitMask bitMatrix,
 	shares [][]byte,
 ) error {
 	root := eds.computeSharesRoot(shares, c)
 
-	if !bytes.Equal(root, columnRoots[c]) {
+	if !bytes.Equal(root, colRoots[c]) {
 		for r := 0; r < int(eds.width); r++ {
 			if !bitMask.Get(r, int(c)) {
 				shares[r] = nil
 			}
 		}
-		return &ErrByzantineColumn{c, shares}
+		return &ErrByzantineCol{c, shares}
 	}
 
 	return nil
@@ -350,13 +350,13 @@ func (eds *ExtendedDataSquare) verifyAgainstColRoots(
 
 func (eds *ExtendedDataSquare) prerepairSanityCheck(
 	rowRoots [][]byte,
-	columnRoots [][]byte,
+	colRoots [][]byte,
 	bitMask bitMatrix,
 	codec Codec,
 ) error {
 	for i := uint(0); i < eds.width; i++ {
 		rowIsComplete := bitMask.RowIsOne(int(i))
-		colIsComplete := bitMask.ColumnIsOne(int(i))
+		colIsComplete := bitMask.ColIsOne(int(i))
 
 		// if there's no missing data in the this row
 		if noMissingData(eds.row(i)) {
@@ -367,10 +367,10 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 		}
 
 		// if there's no missing data in the this col
-		if noMissingData(eds.column(i)) {
+		if noMissingData(eds.col(i)) {
 			// ensure that the roots are equal and that rowMask is a vector
-			if colIsComplete && !bytes.Equal(columnRoots[i], eds.getColRoot(i)) {
-				return fmt.Errorf("bad root input: col %d expected %v got %v", i, columnRoots[i], eds.getColRoot(i))
+			if colIsComplete && !bytes.Equal(colRoots[i], eds.getColRoot(i)) {
+				return fmt.Errorf("bad root input: col %d expected %v got %v", i, colRoots[i], eds.getColRoot(i))
 			}
 		}
 
@@ -385,12 +385,12 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 		}
 
 		if colIsComplete {
-			parityShares, err := codec.Encode(eds.columnSlice(0, i, eds.originalDataWidth))
+			parityShares, err := codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.columnSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				return &ErrByzantineColumn{i, eds.column(i)}
+			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.colSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
+				return &ErrByzantineCol{i, eds.col(i)}
 			}
 		}
 	}

--- a/extendeddatacrossword.go
+++ b/extendeddatacrossword.go
@@ -159,7 +159,7 @@ func (eds *ExtendedDataSquare) solveCrosswordRow(
 	// Prepare shares
 	shares := make([][]byte, eds.width)
 	for c := 0; c < int(eds.width); c++ {
-		vectorData := eds.Row(uint(r))
+		vectorData := eds.row(uint(r))
 
 		if bitMask.Get(r, c) {
 			// As guaranteed by the bitMask, vectorData can't be nil here:
@@ -227,7 +227,7 @@ func (eds *ExtendedDataSquare) solveCrosswordCol(
 	// Prepare shares
 	shares := make([][]byte, eds.width)
 	for r := 0; r < int(eds.width); r++ {
-		vectorData := eds.Column(uint(c))
+		vectorData := eds.column(uint(c))
 
 		if bitMask.Get(r, c) {
 			// As guaranteed by the bitMask, vectorData can't be nil here:
@@ -359,18 +359,18 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 		colIsComplete := bitMask.ColumnIsOne(int(i))
 
 		// if there's no missing data in the this row
-		if noMissingData(eds.Row(i)) {
+		if noMissingData(eds.row(i)) {
 			// ensure that the roots are equal and that rowMask is a vector
-			if rowIsComplete && !bytes.Equal(rowRoots[i], eds.RowRoot(i)) {
-				return fmt.Errorf("bad root input: row %d expected %v got %v", i, rowRoots[i], eds.RowRoot(i))
+			if rowIsComplete && !bytes.Equal(rowRoots[i], eds.getRowRoot(i)) {
+				return fmt.Errorf("bad root input: row %d expected %v got %v", i, rowRoots[i], eds.getRowRoot(i))
 			}
 		}
 
 		// if there's no missing data in the this col
-		if noMissingData(eds.Column(i)) {
+		if noMissingData(eds.column(i)) {
 			// ensure that the roots are equal and that rowMask is a vector
-			if colIsComplete && !bytes.Equal(columnRoots[i], eds.ColRoot(i)) {
-				return fmt.Errorf("bad root input: col %d expected %v got %v", i, columnRoots[i], eds.ColRoot(i))
+			if colIsComplete && !bytes.Equal(columnRoots[i], eds.getColRoot(i)) {
+				return fmt.Errorf("bad root input: col %d expected %v got %v", i, columnRoots[i], eds.getColRoot(i))
 			}
 		}
 
@@ -380,7 +380,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.rowSlice(i, eds.originalDataWidth, eds.originalDataWidth))) {
-				return &ErrByzantineRow{i, eds.Row(i)}
+				return &ErrByzantineRow{i, eds.row(i)}
 			}
 		}
 
@@ -390,7 +390,7 @@ func (eds *ExtendedDataSquare) prerepairSanityCheck(
 				return err
 			}
 			if !bytes.Equal(flattenChunks(parityShares), flattenChunks(eds.columnSlice(eds.originalDataWidth, i, eds.originalDataWidth))) {
-				return &ErrByzantineColumn{i, eds.Column(i)}
+				return &ErrByzantineColumn{i, eds.column(i)}
 			}
 		}
 	}

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -122,9 +122,9 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
-		var byzColumn *ErrByzantineColumn
-		if !errors.As(err, &byzColumn) {
-			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
+		var byzCol *ErrByzantineCol
+		if !errors.As(err, &byzCol) {
+			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
 		}
 
 		corrupted, err = original.deepCopy(codec)
@@ -135,8 +135,8 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
 		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
-		if !errors.As(err, &byzColumn) {
-			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
+		if !errors.As(err, &byzCol) {
+			t.Errorf("did not return a ErrByzantineCol for a bad column; got %v", err)
 		}
 	}
 }

--- a/extendeddatacrossword_test.go
+++ b/extendeddatacrossword_test.go
@@ -41,14 +41,14 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13] = nil, nil
 		var result *ExtendedDataSquare
-		result, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec, NewDefaultTree)
+		result, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
 		if err != nil {
 			t.Errorf("unexpected err while repairing data square: %v, codec: :%s", err, codecName)
 		} else {
-			assert.Equal(t, result.Cell(0, 0), ones)
-			assert.Equal(t, result.Cell(0, 1), twos)
-			assert.Equal(t, result.Cell(1, 0), threes)
-			assert.Equal(t, result.Cell(1, 1), fours)
+			assert.Equal(t, result.getCell(0, 0), ones)
+			assert.Equal(t, result.getCell(0, 1), twos)
+			assert.Equal(t, result.getCell(1, 0), threes)
+			assert.Equal(t, result.getCell(1, 1), fours)
 		}
 
 		flattened = original.flattened()
@@ -56,7 +56,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
 		flattened[8], flattened[9], flattened[10] = nil, nil, nil
 		flattened[12], flattened[13], flattened[14] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), flattened, codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), flattened, codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair an unrepairable square")
 		}
@@ -67,7 +67,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		}
 		corruptChunk := bytes.Repeat([]byte{66}, bufferSize)
 		corrupted.setCell(0, 0, corruptChunk)
-		_, err = RepairExtendedDataSquare(original.RowRoots(), original.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(original.getRowRoots(), original.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if err == nil {
 			t.Errorf("did not return an error on trying to repair a square with bad roots")
 		}
@@ -77,7 +77,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 0, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		var byzRow *ErrByzantineRow
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got: %v", err)
@@ -92,7 +92,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Errorf("could not decode fraud proof shares; got: %v", err)
 		}
 		root := corrupted.computeSharesRoot(rebuiltShares, fraudProof.Index)
-		if bytes.Equal(root, corrupted.RowRoot(fraudProof.Index)) {
+		if bytes.Equal(root, corrupted.getRowRoot(fraudProof.Index)) {
 			// If the roots match, then the fraud proof should be for invalid erasure coding.
 			parityShares, err := codec.Encode(rebuiltShares[0:corrupted.originalDataWidth])
 			if err != nil {
@@ -109,7 +109,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 			t.Fatalf("unexpected err while copying original data: %v, codec: :%s", err, codecName)
 		}
 		corrupted.setCell(0, 3, corruptChunk)
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), corrupted.flattened(), codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), corrupted.flattened(), codec, NewDefaultTree)
 		if !errors.As(err, &byzRow) {
 			t.Errorf("did not return a ErrByzantineRow for a bad row; got %v", err)
 		}
@@ -121,7 +121,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(0, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		var byzColumn *ErrByzantineColumn
 		if !errors.As(err, &byzColumn) {
 			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
@@ -134,7 +134,7 @@ func TestRepairExtendedDataSquare(t *testing.T) {
 		corrupted.setCell(3, 0, corruptChunk)
 		flattened = corrupted.flattened()
 		flattened[1], flattened[2], flattened[3] = nil, nil, nil
-		_, err = RepairExtendedDataSquare(corrupted.RowRoots(), corrupted.ColumnRoots(), flattened, codec, NewDefaultTree)
+		_, err = RepairExtendedDataSquare(corrupted.getRowRoots(), corrupted.getColRoots(), flattened, codec, NewDefaultTree)
 		if !errors.As(err, &byzColumn) {
 			t.Errorf("did not return a ErrByzantineColumn for a bad column; got %v", err)
 		}
@@ -181,8 +181,8 @@ func BenchmarkRepair(b *testing.B) {
 						b.StartTimer()
 
 						_, err := RepairExtendedDataSquare(
-							eds.RowRoots(),
-							eds.ColumnRoots(),
+							eds.getRowRoots(),
+							eds.getColRoots(),
 							flattened,
 							codec,
 							NewDefaultTree,

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -91,11 +91,11 @@ func (eds *ExtendedDataSquare) erasureExtendSquare(codec Codec) error {
 		}
 
 		// Extend vertically
-		shares, err = codec.Encode(eds.columnSlice(0, i, eds.originalDataWidth))
+		shares, err = codec.Encode(eds.colSlice(0, i, eds.originalDataWidth))
 		if err != nil {
 			return err
 		}
-		if err := eds.setColumnSlice(eds.originalDataWidth, i, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
+		if err := eds.setColSlice(eds.originalDataWidth, i, shares[len(shares)-int(eds.originalDataWidth):]); err != nil {
 			return err
 		}
 	}
@@ -133,7 +133,7 @@ func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error)
 // This slice is a copy of the internal column slice.
 func (eds *ExtendedDataSquare) Col(y uint) [][]byte {
 	s := make([][]byte, eds.width)
-	copy(s, eds.columnSlice(0, y, eds.width))
+	copy(s, eds.colSlice(0, y, eds.width))
 	return s
 }
 

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -13,7 +13,11 @@ type ExtendedDataSquare struct {
 }
 
 // ComputeExtendedDataSquare computes the extended data square for some chunks of data.
-func ComputeExtendedDataSquare(data [][]byte, codec Codec, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
+func ComputeExtendedDataSquare(
+	data [][]byte,
+	codec Codec,
+	treeCreatorFn TreeConstructorFn,
+) (*ExtendedDataSquare, error) {
 	if len(data) > codec.maxChunks() {
 		return nil, errors.New("number of chunks exceeds the maximum")
 	}
@@ -33,7 +37,11 @@ func ComputeExtendedDataSquare(data [][]byte, codec Codec, treeCreatorFn TreeCon
 }
 
 // ImportExtendedDataSquare imports an extended data square, represented as flattened chunks of data.
-func ImportExtendedDataSquare(data [][]byte, codec Codec, treeCreatorFn TreeConstructorFn) (*ExtendedDataSquare, error) {
+func ImportExtendedDataSquare(
+	data [][]byte,
+	codec Codec,
+	treeCreatorFn TreeConstructorFn,
+) (*ExtendedDataSquare, error) {
 	if len(data) > 4*codec.maxChunks() {
 		return nil, errors.New("number of chunks exceeds the maximum")
 	}

--- a/extendeddatasquare.go
+++ b/extendeddatasquare.go
@@ -120,3 +120,34 @@ func (eds *ExtendedDataSquare) deepCopy(codec Codec) (ExtendedDataSquare, error)
 	eds, err := ImportExtendedDataSquare(eds.flattened(), codec, eds.createTreeFn)
 	return *eds, err
 }
+
+// Col returns a column slice.
+// This slice is a copy of the internal column slice.
+func (eds *ExtendedDataSquare) Col(y uint) [][]byte {
+	s := make([][]byte, eds.width)
+	copy(s, eds.columnSlice(0, y, eds.width))
+	return s
+}
+
+// ColRoots returns the Merkle roots of all the columns in the square.
+func (eds *ExtendedDataSquare) ColRoots() [][]byte {
+	return eds.getColRoots()
+}
+
+// Row returns a row slice.
+// This slice is a copy of the internal row slice.
+func (eds *ExtendedDataSquare) Row(x uint) [][]byte {
+	s := make([][]byte, eds.width)
+	copy(s, eds.rowSlice(x, 0, eds.width))
+	return s
+}
+
+// RowRoots returns the Merkle roots of all the rows in the square.
+func (eds *ExtendedDataSquare) RowRoots() [][]byte {
+	return eds.getRowRoots()
+}
+
+// Width returns the width of the square.
+func (eds *ExtendedDataSquare) Width() uint {
+	return eds.width
+}

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -1,0 +1,62 @@
+package rsmt2d_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lazyledger/rsmt2d"
+)
+
+func TestRSMT2D(t *testing.T) {
+	// Size of each share, in bytes
+	bufferSize := 64
+	// Init new codec
+	codec := rsmt2d.NewLeoRSFF8Codec()
+
+	ones := bytes.Repeat([]byte{1}, bufferSize)
+	twos := bytes.Repeat([]byte{2}, bufferSize)
+	threes := bytes.Repeat([]byte{3}, bufferSize)
+	fours := bytes.Repeat([]byte{4}, bufferSize)
+
+	// Compute parity shares
+	eds, err := rsmt2d.ComputeExtendedDataSquare(
+		[][]byte{
+			ones, twos,
+			threes, fours,
+		},
+		codec,
+		rsmt2d.NewDefaultTree,
+	)
+	if err != nil {
+		t.Errorf("ComputeExtendedDataSquare failed")
+	}
+
+	// Save all shares in flattended form.
+	// Note: slices returned from Row() an Column() are read-only.
+	// If you need to write to them, copy first.
+	flattened := make([][]byte, 0, eds.Width()*eds.Width())
+	for i := uint(0); i < eds.Width(); i++ {
+		flattened = append(flattened, eds.Row(i)...)
+	}
+
+	// Delete some shares, just enough so that repairing is possible.
+	flattened[0], flattened[2], flattened[3] = nil, nil, nil
+	flattened[4], flattened[5], flattened[6], flattened[7] = nil, nil, nil, nil
+	flattened[8], flattened[9], flattened[10] = nil, nil, nil
+	flattened[12], flattened[13] = nil, nil
+
+	// Repair square.
+	repaired, err := rsmt2d.RepairExtendedDataSquare(
+		eds.RowRoots(),
+		eds.ColRoots(),
+		flattened,
+		codec,
+		rsmt2d.NewDefaultTree,
+	)
+	if err != nil {
+		// err contains information to construct a fraud proof
+		// See extendeddatacrossword_test.go
+		t.Errorf("RepairExtendedDataSquare failed")
+	}
+	_ = repaired
+}

--- a/rsmt2d_test.go
+++ b/rsmt2d_test.go
@@ -31,8 +31,7 @@ func TestRSMT2D(t *testing.T) {
 		t.Errorf("ComputeExtendedDataSquare failed")
 	}
 
-	// Save all shares in flattended form.
-	// Note: slices returned from Row() an Column() are read-only.
+	// Save all shares in flattened form.
 	// If you need to write to them, copy first.
 	flattened := make([][]byte, 0, eds.Width()*eds.Width())
 	for i := uint(0); i < eds.Width(); i++ {

--- a/tree.go
+++ b/tree.go
@@ -2,7 +2,6 @@ package rsmt2d
 
 import (
 	"crypto/sha256"
-	"fmt"
 
 	"github.com/lazyledger/merkletree"
 )
@@ -16,11 +15,9 @@ type SquareIndex struct {
 	Axis, Cell uint
 }
 
-// Tree wraps merkle tree implementations to work with rsmt2d
+// Tree wraps Merkle tree implementations to work with rsmt2d
 type Tree interface {
 	Push(data []byte, idx SquareIndex)
-	// TODO(ismail): is this general enough?
-	Prove(idx int) (merkleRoot []byte, proofSet [][]byte, proofIndex uint64, numLeaves uint64)
 	Root() []byte
 }
 
@@ -42,16 +39,6 @@ func NewDefaultTree() Tree {
 func (d *DefaultTree) Push(data []byte, _idx SquareIndex) {
 	// ignore the idx, as this implementation doesn't need that info
 	d.leaves = append(d.leaves, data)
-}
-
-func (d *DefaultTree) Prove(idx int) (merkleRoot []byte, proofSet [][]byte, proofIndex uint64, numLeaves uint64) {
-	if err := d.Tree.SetIndex(uint64(idx)); err != nil {
-		panic(fmt.Sprintf("don't call prove on a already used tree: %v", err))
-	}
-	for _, l := range d.leaves {
-		d.Tree.Push(l)
-	}
-	return d.Tree.Prove()
 }
 
 func (d *DefaultTree) Root() []byte {


### PR DESCRIPTION
Partially addresses #12.

Don't export `dataSquare` methods, and instead only export `ExtendedDataSquare` methods that wrap those. Functionally mostly the same, except `Row` and `Col` now return copies, so the caller can't accidentally write to internal slices in a bad way.